### PR TITLE
Fix segfaults on x86 64

### DIFF
--- a/Include/Rocket/Core/Platform.h
+++ b/Include/Rocket/Core/Platform.h
@@ -46,6 +46,13 @@
 	#define ROCKET_DEBUG
 #endif
 
+#if defined __x86_64__ || defined _M_X64 || defined __powerpc64__ || defined __alpha__ || defined __ia64__ || defined __s390__ || defined __s390x__
+    #define ROCKET_ARCH_64
+#else
+    #define ROCKET_ARCH_32
+#endif
+
+
 #if defined ROCKET_PLATFORM_WIN32
 	// alignment of a member was sensitive to packing
 	#pragma warning(disable : 4121)

--- a/Include/Rocket/Core/Types.h
+++ b/Include/Rocket/Core/Types.h
@@ -82,7 +82,8 @@ class Dictionary;
 
 // Types for external interfaces.
 typedef void* FileHandle;
-typedef void* TextureHandle;
+//typedef void* TextureHandle;
+typedef uintptr_t TextureHandle;
 typedef void* CompiledGeometryHandle;
 typedef void* DecoratorDataHandle;
 

--- a/Include/Rocket/Core/Variant.h
+++ b/Include/Rocket/Core/Variant.h
@@ -33,6 +33,12 @@
 #include <Rocket/Core/TypeConverter.h>
 #include <list>
 
+#ifdef ROCKET_ARCH_64
+    #define ROCKET_VARIANT_BUFFER_SIZE 32
+#else
+    #define ROCKET_VARIANT_BUFFER_SIZE 16
+#endif
+
 namespace Rocket {
 namespace Core {
 
@@ -150,7 +156,7 @@ private:
 		void Clear();
 		Type type;
 
-		char data[16];
+		char data[ROCKET_VARIANT_BUFFER_SIZE];
 		void* data_ptr;
 
 		mutable int reference_count;


### PR DESCRIPTION
On Linux 64 bits I get segfaults because of a buffer overflow, since in this arch sizeof(void*) is 8 instead of 4, thus sizeof(String) > 16 from char data[16] from Variant::DataBlock.

Another problem is that converting between GLuint and void\* (TextureHandle) is not possible (at least in Linux 64) again because of this 8->4 difference, to fix that and still keep from having to change any code from the samples (and consequently, other existing code), I used the uintptr_t but I don't know what else you expect to receive here, and I have not tested this in other systems. In the GNU stdc++ library these 'pointers' are defined like this:

```
/* Types for `void *' pointers.  */
#if __WORDSIZE == 64
# ifndef __intptr_t_defined
typedef long int        intptr_t;
#  define __intptr_t_defined
# endif
typedef unsigned long int   uintptr_t;
#else
# ifndef __intptr_t_defined
typedef int         intptr_t;
#  define __intptr_t_defined
# endif
typedef unsigned int        uintptr_t;
#endif
```

When I test it in other systems I will update here if no one else does before.
Cheers,
Hilton
