### PR TITLE
Add special #parent token (similar to #document and #self)

### DIFF
--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1179,6 +1179,8 @@ Element* Element::GetElementById(const String& id)
 		return this;
 	else if (id == "#document")
 		return GetOwnerDocument();
+	else if (id == "#parent")
+		return this->parent;
 	else
 	{
 		Element* search_root = GetOwnerDocument();


### PR DESCRIPTION
Add special #parent token (similar to #document and #self) handling in GetElementById.

I found this useful to refer to an outside element from within a template.

E.g.:
                <handle move_target="#parent">...</handle>
                <handle size_target="#parent" class="size_handle"></handle>
