### PR TITLE
Added Length API to FileInterface.

### DIFF
--- a/Include/Rocket/Core/FileInterface.h
+++ b/Include/Rocket/Core/FileInterface.h
@@ -76,6 +76,12 @@ public:
 	/// @return The number of bytes from the origin of the file.
 	virtual size_t Tell(FileHandle file) = 0;
 
+	/// Returns the length of the file.
+	/// The default implementation uses Seek & Tell.
+	/// @param file The handle of the file to be queried.
+	/// @return The length of the file in bytes.
+	virtual size_t Length(FileHandle file);
+
 	/// Called when this file interface is released.
 	virtual void Release();
 

--- a/Source/Core/FileInterface.cpp
+++ b/Source/Core/FileInterface.cpp
@@ -39,6 +39,16 @@ FileInterface::~FileInterface()
 {
 }
 
+// Returns the length of the file.
+size_t FileInterface::Length(FileHandle file)
+{
+    size_t current_position = Tell(file);
+    Seek( file, 0, SEEK_END);
+    size_t length = Tell( file);
+    Seek( file, current_position, SEEK_SET);
+    return length;
+}
+
 // Called when this file interface is released.
 void FileInterface::Release()
 {

--- a/Source/Core/FontDatabase.cpp
+++ b/Source/Core/FontDatabase.cpp
@@ -257,15 +257,7 @@ void* FontDatabase::LoadFace(const String& file_name)
 		return false;
 	}
 
-	// Seek to the end of the file so we can determine its size.
-	if (!file_interface->Seek(handle, 0, SEEK_END))
-	{
-		file_interface->Close(handle);
-		return false;
-	}
-
-	size_t length = file_interface->Tell(handle);
-	file_interface->Seek(handle, 0, SEEK_SET);
+	size_t length = file_interface->Length(handle);
 
 	FT_Byte* buffer = new FT_Byte[length];
 	file_interface->Read(buffer, length, handle);

--- a/Source/Core/StreamFile.cpp
+++ b/Source/Core/StreamFile.cpp
@@ -132,10 +132,7 @@ bool StreamFile::IsWriteReady()
 // Determines the length of the stream.
 void StreamFile::GetLength()
 {
-	size_t current_position = Tell();
-	Seek(0, SEEK_END);
-	length = Tell();
-	Seek(current_position, SEEK_SET);
+	length = GetFileInterface()->Length(file_handle);
 }
 
 }


### PR DESCRIPTION
Getting the file length via seek & tell can be expensive for compressed streams and archive wrappers like PHYSFS. I.e. decompress twice (first to get size and second to get content).

The default impl still uses seek + tell (i.e. not pure virtual).

Cheers,
Frank.
