### PR TITLE
Fix clang build

### DIFF
--- a/Include/Rocket/Core/Vector2.inl
+++ b/Include/Rocket/Core/Vector2.inl
@@ -62,7 +62,7 @@ Type Vector2< Type >::SquaredMagnitude() const
 template < typename Type >
 Vector2< Type > Vector2< Type >::Normalise() const
 {
-	ROCKET_STATIC_ASSERT(false, Invalid_Operation);
+	ROCKET_STATIC_ASSERT(sizeof(Type) == 0, Invalid_Operation);
 	return *this;
 }
 
@@ -81,7 +81,7 @@ Type Vector2< Type >::DotProduct(const Vector2< Type >& rhs) const
 template < typename Type >
 Vector2< Type > Vector2< Type >::Rotate(float theta) const
 {
-	ROCKET_STATIC_ASSERT(false, Invalid_Operation);
+	ROCKET_STATIC_ASSERT(sizeof(Type) == 0, Invalid_Operation);
 	return *this;
 }
 


### PR DESCRIPTION
Clang will complain about templates without valid instantiations, changing the static assert expressions to depend on the template type as hinted by Boost's documentation fixes that.
