### PR TITLE
Fix for issue 20, incorrect system interface refcounting in debugger

### DIFF
--- a/Source/Debugger/SystemInterface.cpp
+++ b/Source/Debugger/SystemInterface.cpp
@@ -36,12 +36,14 @@ SystemInterface::SystemInterface(ElementLog* _log)
 {
 	log = _log;
 	application_interface = Core::GetSystemInterface();
+	application_interface->AddReference();
 	Core::SetSystemInterface(this);
 }
 
 SystemInterface::~SystemInterface()
 {
 	Core::SetSystemInterface(application_interface);
+	application_interface->RemoveReference();
 }
 
 // Get the number of seconds elapsed since the start of the application.


### PR DESCRIPTION
The debugger retreived and hid a pointer to the the old system interface
before replacing it with its own system interface, without updating the
reference count to indicate this additional reference.
That is now resolved as there are an addref before the replacement and a
release when finished with it.
