### PR TITLE
Preserve ratio of replaced elements when resizing

### DIFF
--- a/Source/Core/LayoutEngine.cpp
+++ b/Source/Core/LayoutEngine.cpp
@@ -128,15 +128,28 @@ void LayoutEngine::BuildBox(Box& box, const Vector2f& containing_block, Element*
 	{
 		replaced_element = true;
 
+		Vector2f original_content_area = content_area;
+
 		// The element has resized itself, so we only resize it if a RCSS width or height was set explicitly. A value of
-		// 'auto' (or 'auto-fit', ie, both keywords) means keep the intrinsic dimensions.
+		// 'auto' (or 'auto-fit', ie, both keywords) means keep (or adjust) the intrinsic dimensions.
+		bool auto_width = false, auto_height = false;
 		const Property* width_property = element->GetProperty(WIDTH);
 		if (width_property->unit != Property::KEYWORD)
 			content_area.x = element->ResolveProperty(WIDTH, containing_block.x);
+		else
+			auto_width = true;
 
 		const Property* height_property = element->GetProperty(HEIGHT);
 		if (height_property->unit != Property::KEYWORD)
 			content_area.y = element->ResolveProperty(HEIGHT, containing_block.y);
+		else
+			auto_height = true;
+
+		// If one of the dimensions is 'auto' then we need to scale it such that the original ratio is preserved.
+		if (auto_width && !auto_height)
+			content_area.x = (content_area.y / original_content_area.y) * original_content_area.x;
+		else if (auto_height && !auto_width)
+			content_area.y = (content_area.x / original_content_area.x) * original_content_area.y;
 
 		// Reduce the width and height to make up for borders and padding.
 		content_area.x -= (box.GetEdge(Box::BORDER, Box::LEFT) +


### PR DESCRIPTION
This arranges for replaced elements to retain their aspect ratio when being scaled if they have one and only one of "width: auto" or "height: auto". This is good where the context dimensions/ratio is variable, as is the case with a typical PC game.

[CSS2 10.3.2](http://www.w3.org/TR/CSS2/visudet.html#inline-replaced-width) is the relevant part of the CSS spec:

> If 'height' and 'width' both have computed values of 'auto' and the element has no intrinsic width, but does have an intrinsic height and intrinsic ratio; or if 'width' has a computed value of 'auto', 'height' has some other computed value, and the element does have an intrinsic ratio; then the used value of 'width' is:
> 
> ```
> (used height) * (intrinsic ratio)
> ```
