### PR TITLE
Color multiplier on TiledDecorators and ImageElement

### DIFF
--- a/Include/Rocket/Core/Element.h
+++ b/Include/Rocket/Core/Element.h
@@ -507,7 +507,7 @@ public:
 	/// @return The element's background.
 	ElementBackground* GetElementBackground() const;
 	/// Access the element border.
-	/// @return The element's boder.
+	/// @return The element's border.
 	ElementBorder* GetElementBorder() const;
 	/// Access the element decorators.
 	/// @return The element decoration.

--- a/Source/Core/DecoratorTiled.cpp
+++ b/Source/Core/DecoratorTiled.cpp
@@ -34,6 +34,7 @@ namespace Core {
 
 DecoratorTiled::DecoratorTiled()
 {
+	color_multiplier = Colourb(255, 255, 255, 255);
 }
 
 DecoratorTiled::~DecoratorTiled()
@@ -105,7 +106,7 @@ Vector2f DecoratorTiled::Tile::GetDimensions(Element* element)
 }
 
 // Generates geometry to render this tile across a surface.
-void DecoratorTiled::Tile::GenerateGeometry(std::vector< Vertex >& vertices, std::vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions) const
+void DecoratorTiled::Tile::GenerateGeometry(std::vector< Vertex >& vertices, std::vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions, const Colourb& color_multiplier) const
 {
 	RenderInterface* render_interface = element->GetRenderInterface();
 	TileDataMap::iterator data_iterator = data.find(render_interface);
@@ -244,7 +245,7 @@ void DecoratorTiled::Tile::GenerateGeometry(std::vector< Vertex >& vertices, std
 			tile_position.x = surface_origin.x + (float) tile_dimensions.x * x;
 			tile_size.x = (float) (x < num_tiles[0] - 1 ? tile_dimensions.x : final_tile_dimensions.x);
 
-			GeometryUtilities::GenerateQuad(new_vertices, new_indices, tile_position, tile_size, Colourb(255, 255, 255), tile_texcoords[0], tile_texcoords[1], index_offset);
+			GeometryUtilities::GenerateQuad(new_vertices, new_indices, tile_position, tile_size, color_multiplier, tile_texcoords[0], tile_texcoords[1], index_offset);
 			new_vertices += 4;
 			new_indices += 6;
 			index_offset += 4;

--- a/Source/Core/DecoratorTiled.h
+++ b/Source/Core/DecoratorTiled.h
@@ -97,7 +97,7 @@ public:
 		/// @param[in] surface_origin The starting point of the first tile to generate.
 		/// @param[in] surface_dimensions The dimensions of the surface to be tiled.
 		/// @param[in] tile_dimensions The dimensions to render this tile at.
-		void GenerateGeometry(std::vector< Vertex >& vertices, std::vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions) const;
+		void GenerateGeometry(std::vector< Vertex >& vertices, std::vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions, const Colourb& color_multiplier = Colourb(255, 255, 255)) const;
 
 		struct TileData
 		{
@@ -117,12 +117,19 @@ public:
 		TileOrientation orientation;
 	};
 
+	Colourb & GetColorMultiplier()
+	{
+		return color_multiplier;
+	}
+
 protected:
 	/// Scales a tile dimensions by a fixed value along one axis.
 	/// @param tile_dimensions[in, out] The tile dimensions to scale.
 	/// @param axis_value[in] The fixed value to scale against.
 	/// @param axis[in] The axis to scale against; either 0 (for x) or 1 (for y).
 	void ScaleTileDimensions(Vector2f& tile_dimensions, float axis_value, int axis);
+
+	Colourb color_multiplier;
 };
 
 }

--- a/Source/Core/DecoratorTiledBox.cpp
+++ b/Source/Core/DecoratorTiledBox.cpp
@@ -203,21 +203,26 @@ DecoratorDataHandle DecoratorTiledBox::GenerateElementData(Element* element)
 											element,
 											Vector2f(0, 0),
 											top_left_dimensions,
-											top_left_dimensions);
+											top_left_dimensions,
+											color_multiplier);
+
 	// Generate the geometry for the top edge tiles.
 	tiles[TOP_EDGE].GenerateGeometry(data->geometry[tiles[TOP_EDGE].texture_index]->GetVertices(),
 									 data->geometry[tiles[TOP_EDGE].texture_index]->GetIndices(),
 									 element,
 									 Vector2f(top_left_dimensions.x, 0),
 									 Vector2f(padded_size.x - (top_left_dimensions.x + top_right_dimensions.x), top_dimensions.y),
-									 top_dimensions);
+									 top_dimensions,
+									 color_multiplier);
+
 	// Generate the geometry for the top-right tile.
 	tiles[TOP_RIGHT_CORNER].GenerateGeometry(data->geometry[tiles[TOP_RIGHT_CORNER].texture_index]->GetVertices(),
 											 data->geometry[tiles[TOP_RIGHT_CORNER].texture_index]->GetIndices(),
 											 element,
 											 Vector2f(padded_size.x - top_right_dimensions.x, 0),
 											 top_right_dimensions,
-											 top_right_dimensions);
+											 top_right_dimensions,
+											 color_multiplier);
 
 	// Generate the geometry for the left side.
 	tiles[LEFT_EDGE].GenerateGeometry(data->geometry[tiles[LEFT_EDGE].texture_index]->GetVertices(),
@@ -225,7 +230,8 @@ DecoratorDataHandle DecoratorTiledBox::GenerateElementData(Element* element)
 									  element,
 									  Vector2f(0, top_left_dimensions.y),
 									  Vector2f(left_dimensions.x, padded_size.y - (top_left_dimensions.y + bottom_left_dimensions.y)),
-									  left_dimensions);
+									  left_dimensions,
+									  color_multiplier);
 
 	// Generate the geometry for the right side.
 	tiles[RIGHT_EDGE].GenerateGeometry(data->geometry[tiles[RIGHT_EDGE].texture_index]->GetVertices(),
@@ -233,7 +239,8 @@ DecoratorDataHandle DecoratorTiledBox::GenerateElementData(Element* element)
 									   element,
 									   Vector2f((padded_size.x - right_dimensions.x), top_right_dimensions.y),
 									   Vector2f(right_dimensions.x, padded_size.y - (top_right_dimensions.y + bottom_right_dimensions.y)),
-									   right_dimensions);
+									   right_dimensions,
+									   color_multiplier);
 
 	// Generate the geometry for the bottom-left tile.
 	tiles[BOTTOM_LEFT_CORNER].GenerateGeometry(data->geometry[tiles[BOTTOM_LEFT_CORNER].texture_index]->GetVertices(),
@@ -241,21 +248,26 @@ DecoratorDataHandle DecoratorTiledBox::GenerateElementData(Element* element)
 											   element,
 											   Vector2f(0, padded_size.y - bottom_left_dimensions.y),
 											   bottom_left_dimensions,
-											   bottom_left_dimensions);
+											   bottom_left_dimensions,
+											   color_multiplier);
+
 	// Generate the geometry for the bottom edge tiles.
 	tiles[BOTTOM_EDGE].GenerateGeometry(data->geometry[tiles[BOTTOM_EDGE].texture_index]->GetVertices(),
 										data->geometry[tiles[BOTTOM_EDGE].texture_index]->GetIndices(),
 										element,
 										Vector2f(bottom_left_dimensions.x, padded_size.y - bottom_dimensions.y),
 										Vector2f(padded_size.x - (bottom_left_dimensions.x + bottom_right_dimensions.x), bottom_dimensions.y),
-										bottom_dimensions);
+										bottom_dimensions,
+										color_multiplier);
+
 	// Generate the geometry for the bottom-right tile.
 	tiles[BOTTOM_RIGHT_CORNER].GenerateGeometry(data->geometry[tiles[BOTTOM_RIGHT_CORNER].texture_index]->GetVertices(),
 												data->geometry[tiles[BOTTOM_RIGHT_CORNER].texture_index]->GetIndices(),
 												element,
 												Vector2f(padded_size.x - bottom_right_dimensions.x, padded_size.y - bottom_right_dimensions.y),
 												bottom_right_dimensions,
-												bottom_right_dimensions);
+												bottom_right_dimensions,
+												color_multiplier);
 
 	// Generate the centre geometry.
 	if (tiles[CENTRE].texture_index >= 0)
@@ -269,7 +281,8 @@ DecoratorDataHandle DecoratorTiledBox::GenerateElementData(Element* element)
 									   element,
 									   Vector2f(left_dimensions.x, top_dimensions.y),
 									   centre_surface_dimensions,
-									   centre_dimensions);
+									   centre_dimensions,
+									   color_multiplier);
 	}
 
 	// Set the textures on the geometry.

--- a/Source/Core/DecoratorTiledBoxInstancer.cpp
+++ b/Source/Core/DecoratorTiledBoxInstancer.cpp
@@ -45,6 +45,8 @@ DecoratorTiledBoxInstancer::DecoratorTiledBoxInstancer()
 	RegisterTileProperty("bottom-image", true);
 
 	RegisterTileProperty("center-image", true);
+
+	RegisterProperty("color-multiplier", "white").AddParser(COLOR);
 }
 
 DecoratorTiledBoxInstancer::~DecoratorTiledBoxInstancer()
@@ -69,6 +71,9 @@ Decorator* DecoratorTiledBoxInstancer::InstanceDecorator(const String& ROCKET_UN
 	GetTileProperties(tiles[8], texture_names[8], rcss_paths[8], properties, "center-image");
 
 	DecoratorTiledBox* decorator = new DecoratorTiledBox();
+
+	decorator->GetColorMultiplier() = properties.GetProperty("color-multiplier")->value.Get< Colourb >();
+
 	if (decorator->Initialise(tiles, texture_names, rcss_paths))
 		return decorator;
 

--- a/Source/Core/DecoratorTiledHorizontal.cpp
+++ b/Source/Core/DecoratorTiledHorizontal.cpp
@@ -125,11 +125,11 @@ DecoratorDataHandle DecoratorTiledHorizontal::GenerateElementData(Element* eleme
 	}
 
 	// Generate the geometry for the left tile.
-	tiles[LEFT].GenerateGeometry(data->geometry[tiles[LEFT].texture_index]->GetVertices(), data->geometry[tiles[LEFT].texture_index]->GetIndices(), element, Vector2f(0, 0), left_dimensions, left_dimensions);
+	tiles[LEFT].GenerateGeometry(data->geometry[tiles[LEFT].texture_index]->GetVertices(), data->geometry[tiles[LEFT].texture_index]->GetIndices(), element, Vector2f(0, 0), left_dimensions, left_dimensions, color_multiplier);
 	// Generate the geometry for the centre tiles.
-	tiles[CENTRE].GenerateGeometry(data->geometry[tiles[CENTRE].texture_index]->GetVertices(), data->geometry[tiles[CENTRE].texture_index]->GetIndices(), element, Vector2f(left_dimensions.x, 0), Vector2f(padded_size.x - (left_dimensions.x + right_dimensions.x), centre_dimensions.y), centre_dimensions);
+	tiles[CENTRE].GenerateGeometry(data->geometry[tiles[CENTRE].texture_index]->GetVertices(), data->geometry[tiles[CENTRE].texture_index]->GetIndices(), element, Vector2f(left_dimensions.x, 0), Vector2f(padded_size.x - (left_dimensions.x + right_dimensions.x), centre_dimensions.y), centre_dimensions, color_multiplier);
 	// Generate the geometry for the right tile.
-	tiles[RIGHT].GenerateGeometry(data->geometry[tiles[RIGHT].texture_index]->GetVertices(), data->geometry[tiles[RIGHT].texture_index]->GetIndices(), element, Vector2f(padded_size.x - right_dimensions.x, 0), right_dimensions, right_dimensions);
+	tiles[RIGHT].GenerateGeometry(data->geometry[tiles[RIGHT].texture_index]->GetVertices(), data->geometry[tiles[RIGHT].texture_index]->GetIndices(), element, Vector2f(padded_size.x - right_dimensions.x, 0), right_dimensions, right_dimensions, color_multiplier);
 
 	// Set the textures on the geometry.
 	const Texture* texture = NULL;

--- a/Source/Core/DecoratorTiledHorizontalInstancer.cpp
+++ b/Source/Core/DecoratorTiledHorizontalInstancer.cpp
@@ -37,6 +37,7 @@ DecoratorTiledHorizontalInstancer::DecoratorTiledHorizontalInstancer()
 	RegisterTileProperty("left-image", false);
 	RegisterTileProperty("right-image", false);
 	RegisterTileProperty("center-image", true);
+	RegisterProperty("color-multiplier", "white").AddParser(COLOR);
 }
 
 DecoratorTiledHorizontalInstancer::~DecoratorTiledHorizontalInstancer()
@@ -55,6 +56,9 @@ Decorator* DecoratorTiledHorizontalInstancer::InstanceDecorator(const String& RO
 	GetTileProperties(tiles[2], texture_names[2], rcss_paths[2], properties, "center-image");
 
 	DecoratorTiledHorizontal* decorator = new DecoratorTiledHorizontal();
+
+	decorator->GetColorMultiplier() = properties.GetProperty("color-multiplier")->value.Get< Colourb >();
+
 	if (decorator->Initialise(tiles, texture_names, rcss_paths))
 		return decorator;
 

--- a/Source/Core/DecoratorTiledImage.cpp
+++ b/Source/Core/DecoratorTiledImage.cpp
@@ -64,7 +64,7 @@ DecoratorDataHandle DecoratorTiledImage::GenerateElementData(Element* element)
 	data->SetTexture(GetTexture());
 
 	// Generate the geometry for the tile.
-	tile.GenerateGeometry(data->GetVertices(), data->GetIndices(), element, Vector2f(0, 0), element->GetBox().GetSize(Box::PADDING), tile.GetDimensions(element));
+	tile.GenerateGeometry(data->GetVertices(), data->GetIndices(), element, Vector2f(0, 0), element->GetBox().GetSize(Box::PADDING), tile.GetDimensions(element), color_multiplier);
 
 	return reinterpret_cast<DecoratorDataHandle>(data);
 }

--- a/Source/Core/DecoratorTiledImageInstancer.cpp
+++ b/Source/Core/DecoratorTiledImageInstancer.cpp
@@ -35,6 +35,7 @@ namespace Core {
 DecoratorTiledImageInstancer::DecoratorTiledImageInstancer()
 {
 	RegisterTileProperty("image", false);
+	RegisterProperty("color-multiplier", "white").AddParser(COLOR);
 }
 
 DecoratorTiledImageInstancer::~DecoratorTiledImageInstancer()
@@ -51,6 +52,9 @@ Decorator* DecoratorTiledImageInstancer::InstanceDecorator(const String& ROCKET_
 	GetTileProperties(tile, texture_name, rcss_path, properties, "image");
 
 	DecoratorTiledImage* decorator = new DecoratorTiledImage();
+
+	decorator->GetColorMultiplier() = properties.GetProperty("color-multiplier")->value.Get< Colourb >();
+
 	if (decorator->Initialise(tile, texture_name, rcss_path))
 		return decorator;
 

--- a/Source/Core/DecoratorTiledInstancer.cpp
+++ b/Source/Core/DecoratorTiledInstancer.cpp
@@ -39,7 +39,7 @@ DecoratorTiledInstancer::~DecoratorTiledInstancer()
 // Adds the property declarations for a tile.
 void DecoratorTiledInstancer::RegisterTileProperty(const String& name, bool register_repeat_modes)
 {
-	RegisterProperty(String(32, "%s-src", name.CString()), "").AddParser("string");
+	RegisterProperty(String (32, "%s-src", name.CString()), "").AddParser("string");
 	RegisterProperty(String(32, "%s-s-begin", name.CString()), "0").AddParser("number");
 	RegisterProperty(String(32, "%s-s-end", name.CString()), "1").AddParser("number");
 	RegisterProperty(String(32, "%s-t-begin", name.CString()), "0").AddParser("number");

--- a/Source/Core/DecoratorTiledVertical.cpp
+++ b/Source/Core/DecoratorTiledVertical.cpp
@@ -126,11 +126,11 @@ DecoratorDataHandle DecoratorTiledVertical::GenerateElementData(Element* element
 	}
 
 	// Generate the geometry for the left tile.
-	tiles[TOP].GenerateGeometry(data->geometry[tiles[TOP].texture_index]->GetVertices(), data->geometry[tiles[TOP].texture_index]->GetIndices(), element, Vector2f(0, 0), top_dimensions, top_dimensions);
+	tiles[TOP].GenerateGeometry(data->geometry[tiles[TOP].texture_index]->GetVertices(), data->geometry[tiles[TOP].texture_index]->GetIndices(), element, Vector2f(0, 0), top_dimensions, top_dimensions, color_multiplier);
 	// Generate the geometry for the centre tiles.
-	tiles[CENTRE].GenerateGeometry(data->geometry[tiles[CENTRE].texture_index]->GetVertices(), data->geometry[tiles[CENTRE].texture_index]->GetIndices(), element, Vector2f(0, top_dimensions.y), Vector2f(centre_dimensions.x, padded_size.y - (top_dimensions.y + bottom_dimensions.y)), centre_dimensions);
+	tiles[CENTRE].GenerateGeometry(data->geometry[tiles[CENTRE].texture_index]->GetVertices(), data->geometry[tiles[CENTRE].texture_index]->GetIndices(), element, Vector2f(0, top_dimensions.y), Vector2f(centre_dimensions.x, padded_size.y - (top_dimensions.y + bottom_dimensions.y)), centre_dimensions, color_multiplier);
 	// Generate the geometry for the right tile.
-	tiles[BOTTOM].GenerateGeometry(data->geometry[tiles[BOTTOM].texture_index]->GetVertices(), data->geometry[tiles[BOTTOM].texture_index]->GetIndices(), element, Vector2f(0, padded_size.y - bottom_dimensions.y), bottom_dimensions, bottom_dimensions);
+	tiles[BOTTOM].GenerateGeometry(data->geometry[tiles[BOTTOM].texture_index]->GetVertices(), data->geometry[tiles[BOTTOM].texture_index]->GetIndices(), element, Vector2f(0, padded_size.y - bottom_dimensions.y), bottom_dimensions, bottom_dimensions, color_multiplier);
 
 	// Set the textures on the geometry.
 	const Texture* texture = NULL;

--- a/Source/Core/DecoratorTiledVerticalInstancer.cpp
+++ b/Source/Core/DecoratorTiledVerticalInstancer.cpp
@@ -37,6 +37,7 @@ DecoratorTiledVerticalInstancer::DecoratorTiledVerticalInstancer()
 	RegisterTileProperty("top-image", false);
 	RegisterTileProperty("bottom-image", false);
 	RegisterTileProperty("center-image", true);
+	RegisterProperty("color-multiplier", "white").AddParser(COLOR);
 }
 
 DecoratorTiledVerticalInstancer::~DecoratorTiledVerticalInstancer()
@@ -55,6 +56,9 @@ Decorator* DecoratorTiledVerticalInstancer::InstanceDecorator(const String& ROCK
 	GetTileProperties(tiles[2], texture_names[2], rcss_paths[2], properties, "center-image");
 
 	DecoratorTiledVertical* decorator = new DecoratorTiledVertical();
+
+	decorator->GetColorMultiplier() = properties.GetProperty("color-multiplier")->value.Get< Colourb >();
+
 	if (decorator->Initialise(tiles, texture_names, rcss_paths))
 		return decorator;
 

--- a/Source/Core/ElementImage.cpp
+++ b/Source/Core/ElementImage.cpp
@@ -156,6 +156,18 @@ void ElementImage::OnAttributeChange(const Rocket::Core::AttributeNameList& chan
 		DirtyLayout();
 }
 
+// Called when properties on the element are changed.
+void ElementImage::OnPropertyChange(const PropertyNameList& changed_properties)
+{
+	Rocket::Core::Element::OnPropertyChange(changed_properties);
+
+	// Check if color property has been changed.
+	if (changed_properties.find(COLOR) != changed_properties.end() )
+	{
+		geometry_dirty = true;
+	}
+}
+
 // Regenerates the element's geometry.
 void ElementImage::ProcessEvent(Rocket::Core::Event& event)
 {
@@ -178,6 +190,8 @@ void ElementImage::GenerateGeometry()
 
 	vertices.resize(4);
 	indices.resize(6);
+
+	Colourb color = GetProperty(COLOR)->value.Get< Colourb >();
 
 	// Generate the texture coordinates.
 	Vector2f texcoords[2];
@@ -203,9 +217,9 @@ void ElementImage::GenerateGeometry()
 
 	Rocket::Core::GeometryUtilities::GenerateQuad(&vertices[0],									// vertices to write to
 												  &indices[0],									// indices to write to
-												  Vector2f(0, 0),					// origin of the quad
+												  Vector2f(0, 0),								// origin of the quad
 												  GetBox().GetSize(Rocket::Core::Box::CONTENT),	// size of the quad
-												  Colourb(255, 255, 255, 255),		// colour of the vertices
+												  color,										// colour of the vertices
 												  texcoords[0],									// top-left texture coordinate
 												  texcoords[1]);								// top-right texture coordinate
 

--- a/Source/Core/ElementImage.h
+++ b/Source/Core/ElementImage.h
@@ -83,6 +83,9 @@ protected:
 	/// Checks for changes to the image's source or dimensions.
 	/// @param[in] changed_attributes A list of attributes changed on the element.
 	virtual void OnAttributeChange(const AttributeNameList& changed_attributes);
+	/// Called when properties on the element are changed.
+	/// @param[in] changed_properties The properties changed on the element.
+	virtual void OnPropertyChange(const PropertyNameList& changed_properties);
 
 	/// Regenerates the element's geometry on a resize event.
 	/// @param[in] event The event to process.


### PR DESCRIPTION
Hi,

I needed to do some color effect on elements so I've made 2 changes :
1. I've added a 'color-multiplier' property on tiled decorators:
   bar-decorator:image;
   bar-color-multiplier:#12345678;
   ...
   I'm not using this property because I figured out that you can't modify decorators at run-time.
   But it's working so maybe it can be useful to someone ;)
2. I've multiplied the texture from an image element by the 'color' property.
   This is what I'm using to do some color effects.

Let me know your opinion!

Cheers,
gogoprog
