### PR TITLE
Fixed drag & drop

### DIFF
--- a/Samples/basic/drag/src/DragListener.cpp
+++ b/Samples/basic/drag/src/DragListener.cpp
@@ -42,7 +42,7 @@ void DragListener::ProcessEvent(Rocket::Core::Event& event)
 	{
 		Rocket::Core::Element* dest_container = event.GetCurrentElement();
 		Rocket::Core::Element* dest_element = event.GetTargetElement();
-		Rocket::Core::Element* drag_element = static_cast< Rocket::Core::Element* >(event.GetParameter< void* >("drag_element", NULL));
+		Rocket::Core::Element* drag_element = *static_cast< Rocket::Core::Element** >(event.GetParameter< void* >("drag_element", NULL));
 
 		if (dest_container == dest_element)
 		{

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -59,6 +59,8 @@ Context::Context(const String& name) : name(name), mouse_position(0, 0), dimensi
 		if (element != NULL)
 			element->RemoveReference();
 	}
+	else
+		cursor_proxy->context = this;
 
 	document_focus_history.push_back(root);
 	focus = root;


### PR DESCRIPTION
Fixed initialization of cursor_proxy in Context's ctor allowing the proxy to be rendered: fixes missing drag&drop cloned elements (which are attached to cursor_proxy).

Also, seems like Variants store pointers as pointers-to-pointers - fixed code that assumed plain pointers in drag&drop example.
