### PR TITLE
A bugfix and a new feature for datagrid cells

### DIFF
--- a/Include/Rocket/Controls/ElementDataGridCell.h
+++ b/Include/Rocket/Controls/ElementDataGridCell.h
@@ -47,12 +47,14 @@ public:
 	ElementDataGridCell(const Rocket::Core::String& tag);
 	virtual ~ElementDataGridCell();
 
-	void Initialise(Core::Element* header);
+	void Initialise(int column, Core::Element* header);
+	int GetColumn();
 
 protected:
 	virtual void ProcessEvent(Core::Event& event);
 
 private:
+	int column;
 	Core::Element* header;
 };
 

--- a/Source/Controls/ElementDataGridCell.cpp
+++ b/Source/Controls/ElementDataGridCell.cpp
@@ -39,18 +39,27 @@ ElementDataGridCell::ElementDataGridCell(const Rocket::Core::String& tag) : Core
 
 ElementDataGridCell::~ElementDataGridCell()
 {
-	if (header)
+	if (header) {
 		header->RemoveEventListener("resize", this);
+		header->RemoveReference();
+	}
 }
 
-void ElementDataGridCell::Initialise(Core::Element* _header)
+void ElementDataGridCell::Initialise(int _column, Core::Element* _header)
 {
+	column = _column;
 	header = _header;
 	if (header)
 	{
+		header->AddReference();
 		header->AddEventListener("resize", this);
 		SetProperty("width", Core::Property(header->GetBox().GetSize(Core::Box::MARGIN).x, Core::Property::PX));
 	}
+}
+
+int ElementDataGridCell::GetColumn()
+{
+	return column;
 }
 
 void ElementDataGridCell::ProcessEvent(Core::Event& event)

--- a/Source/Controls/ElementDataGridRow.cpp
+++ b/Source/Controls/ElementDataGridRow.cpp
@@ -82,7 +82,7 @@ void ElementDataGridRow::Initialise(ElementDataGrid* _parent_grid, ElementDataGr
 	for (int i = 0; i < num_columns; i++)
 	{
 		ElementDataGridCell* cell = dynamic_cast< ElementDataGridCell* >(Core::Factory::InstanceElement(this, "#rktctl_datagridcell", "datagridcell", cell_attributes));
-		cell->Initialise(header_row->GetChild(i));
+		cell->Initialise(i, header_row->GetChild(i));
 		cell->SetProperty("display", Rocket::Core::Property(Rocket::Core::DISPLAY_INLINE_BLOCK, Rocket::Core::Property::KEYWORD));
 		AppendChild(cell);
 		cell->RemoveReference();


### PR DESCRIPTION
Feature: add DatagridCell::GetColumn method.
Bugifx: datagrid cells now properly reference and dereference parent header elements.
