### PR TITLE
Url encoding fixes

### DIFF
--- a/Include/Rocket/Core/URL.h
+++ b/Include/Rocket/Core/URL.h
@@ -115,8 +115,19 @@ public:
 	/// Less-than operator for use as a key in STL containers.
 	bool operator<(const URL& rhs) const;
 
+	/// Since URLs often contain characters outside the ASCII set, 
+	/// the URL has to be converted into a valid ASCII format and back.
+	static String UrlEncode(const String &value);
+	static String UrlDecode(const String &value);
+
 private:
 	void ConstructURL() const;
+
+	/// Portable character check (remember EBCDIC). Do not use isalnum() because
+	/// its behavior is altered by the current locale.
+	/// See http://tools.ietf.org/html/rfc3986#section-2.3
+	/// (copied from libcurl sources)
+	static bool IsUnreservedChar(const char c);
 
 	mutable String url;
 	String protocol;

--- a/Source/Core/ElementTextDefault.cpp
+++ b/Source/Core/ElementTextDefault.cpp
@@ -472,6 +472,8 @@ static bool BuildToken(WString& token, const word*& token_begin, const word* str
 					character = '>';
 				else if (ucs2_escape_code == "amp")
 					character = '&';
+				else if (ucs2_escape_code == "quot")
+					character = '"';
 				else if (ucs2_escape_code == "nbsp")
 				{
 					character = ' ';


### PR DESCRIPTION
Recognize &quot; as double quote in XML encoding.
Add URL::Urlencode and URL::Urldecode, use them to properly encode query string parameters.
When constructing URL, only add scheme to the URL if the host part isn't empty: URL such as http:///something.rml don't make sense.
