### PR TITLE
Added method for loading font from memory autodetecting info.

### DIFF
--- a/Include/Rocket/Core/FontDatabase.h
+++ b/Include/Rocket/Core/FontDatabase.h
@@ -63,6 +63,11 @@ public:
 	/// @param[in] weight The weight of the face (normal or bold).
 	/// @return True if the face was loaded successfully, false otherwise.
 	static bool LoadFontFace(const String& file_name, const String& family, Font::Style style, Font::Weight weight);
+	/// Adds a new font face to the database, loading from memory. The face's family, style and weight will be determined from the face itself.
+	/// @param[in] data The font data.
+	/// @param[in] data_length Length of the data.
+	/// @return True if the face was loaded successfully, false otherwise.
+	static bool LoadFontFace(const byte* data, int data_length);
 	/// Adds a new font face to the database, loading from memory.
 	/// @param[in] data The font data.
 	/// @param[in] data_length Length of the data.

--- a/Source/Core/FontDatabase.cpp
+++ b/Source/Core/FontDatabase.cpp
@@ -89,7 +89,7 @@ void FontDatabase::Shutdown()
 	}
 }
 
-// Adds a new font face to the database, ignoring any family, style and weight information stored in the face itself.
+// Loads a new font face.
 bool FontDatabase::LoadFontFace(const String& file_name)
 {
 	FT_Face ft_face = (FT_Face) instance->LoadFace(file_name);
@@ -114,7 +114,7 @@ bool FontDatabase::LoadFontFace(const String& file_name)
 	}
 }
 
-// Loads a new font face.
+// Adds a new font face to the database, ignoring any family, style and weight information stored in the face itself.
 bool FontDatabase::LoadFontFace(const String& file_name, const String& family, Font::Style style, Font::Weight weight)
 {
 	FT_Face ft_face = (FT_Face) instance->LoadFace(file_name);
@@ -137,6 +137,31 @@ bool FontDatabase::LoadFontFace(const String& file_name, const String& family, F
 }
 
 // Adds a new font face to the database, loading from memory.
+bool FontDatabase::LoadFontFace(const byte* data, int data_length)
+{
+	FT_Face ft_face = (FT_Face) instance->LoadFace(data, data_length, "memory", false);
+	if (ft_face == NULL)
+	{
+		Log::Message(Log::LT_ERROR, "Failed to load font face from byte stream.");
+		return false;
+	}
+
+	Font::Style style = ft_face->style_flags & FT_STYLE_FLAG_ITALIC ? Font::STYLE_ITALIC : Font::STYLE_NORMAL;
+	Font::Weight weight = ft_face->style_flags & FT_STYLE_FLAG_BOLD ? Font::WEIGHT_BOLD : Font::WEIGHT_NORMAL;
+
+	if (instance->AddFace(ft_face, ft_face->family_name, style, weight, false))
+	{
+		Log::Message(Log::LT_INFO, "Loaded font face %s %s (from byte stream).", ft_face->family_name, ft_face->style_name);
+		return true;
+	}
+	else
+	{
+		Log::Message(Log::LT_ERROR, "Failed to load font face %s %s (from byte stream).", ft_face->family_name, ft_face->style_name);
+		return false;
+	}
+}
+
+// Adds a new font face to the database, loading from memory, ignoring any family, style and weight information stored in the face itself.
 bool FontDatabase::LoadFontFace(const byte* data, int data_length, const String& family, Font::Style style, Font::Weight weight)
 {
 	FT_Face ft_face = (FT_Face) instance->LoadFace(data, data_length, "memory", false);


### PR DESCRIPTION
Added method for loading font from memory getting the family, style and weight
information from the font data (just like it's already done when loading from
file).
