### PR TITLE
Stop gcc with -Wswitch complaining about missing NONE

### DIFF
--- a/Include/Rocket/Core/Variant.inl
+++ b/Include/Rocket/Core/Variant.inl
@@ -81,6 +81,10 @@ bool Variant::GetInto(T& value) const
 		case VOIDPTR:
 			return TypeConverter< void*, T >::Convert((void*)data, value);
 		break;
+
+		case NONE:
+		break;
+
 	}
 
 	return false;


### PR DESCRIPTION
Without this, I get the following compilation warning:

```
../include/Rocket/Core/Variant.inl|40|warning: enumeration value ‘NONE’ not handled in switch [-Wswitch]|
```

Thanks!
