### PR TITLE
Lock the layout while adding/replacing/removing nodes

### DIFF
--- a/Include/Rocket/Core/Element.h
+++ b/Include/Rocket/Core/Element.h
@@ -574,6 +574,9 @@ protected:
 	/// Returns true if the element has been marked as needing a re-layout.
 	virtual bool IsLayoutDirty();
 
+	/// Increment/Decrement the layout lock
+	virtual void LockLayout(bool lock);
+
 	/// Forces a reevaluation of applicable font effects.
 	virtual void DirtyFont();
 

--- a/Include/Rocket/Core/ElementDocument.h
+++ b/Include/Rocket/Core/ElementDocument.h
@@ -127,7 +127,7 @@ public:
 	virtual void LoadScript(Stream* stream, const String& source_name);
 
 	/// Updates the layout if necessary.
-	inline void UpdateLayout() { if (layout_dirty && lock_layout == 0) _UpdateLayout(); }
+	void UpdateLayout();
 	/// Updates the position of the document based on the style properties.
 	void UpdatePosition();
 	

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -359,6 +359,12 @@ bool ElementDocument::IsLayoutDirty()
 	return layout_dirty;
 }
 
+void ElementDocument::UpdateLayout() 
+{ 
+	if (layout_dirty && lock_layout == 0) 
+		_UpdateLayout();
+}
+
 // Refreshes the document layout if required.
 void ElementDocument::OnUpdate()
 {


### PR DESCRIPTION
Experimental optimization: postpones the re-layout until after we're finished modifying the DOM tree to avoid redundant re-layouts.
