### PR TITLE
Optimize some of the string class operators

### DIFF
--- a/Include/Rocket/Core/String.h
+++ b/Include/Rocket/Core/String.h
@@ -49,6 +49,25 @@ ROCKETCORE_API int StringBase<char>::FormatString(StringBase<char>::size_type ma
 // Global operators for adding C strings to strings.
 ROCKETCORE_API String operator+(const char* cstring, const String& string);
 
+// partial specialization follows
+template<>
+ROCKETCORE_API inline bool StringBase< char >::operator<(const char * compare) const
+{
+	return strcmp( value, compare ) < 0;
+}
+
+template<>
+ROCKETCORE_API inline bool StringBase< char >::operator==(const char * compare) const
+{
+	return strcmp( value, compare ) == 0;
+}
+
+template<>
+ROCKETCORE_API inline bool StringBase< char >::operator!=(const char * compare) const
+{
+	return strcmp( value, compare ) != 0;
+}
+
 // Redefine Windows APIs as their STDC counterparts.
 #ifdef ROCKET_PLATFORM_WIN32
 	#define strcasecmp stricmp

--- a/Include/Rocket/Core/StringBase.inl
+++ b/Include/Rocket/Core/StringBase.inl
@@ -357,7 +357,7 @@ StringBase< T > StringBase< T >::ToLower() const
 template< typename T >
 StringBase< T > StringBase< T >::ToUpper() const
 {
-	// Loop through the string, looking for an uppercase character
+	// Loop through the string, looking for an lowercase character
 	size_t copy_index = npos;
 	for (size_t i = 0; i < length; i++)
 	{
@@ -466,7 +466,9 @@ StringBase< T >& StringBase< T >::operator=(const T* assign)
 template< typename T >
 StringBase< T >& StringBase< T >::operator=(const StringBase< T >& assign)
 {	
-	return Assign(assign);
+	StringBase< T >&out = Assign(assign);
+	out.hash = assign.hash;
+	return out;
 }
 
 template< typename T >


### PR DESCRIPTION
For single-byte strings, resolve <, = and != operators to strcmp
For common = operator, copy hash value from source to destination
