### PR TITLE
Improved Python bindings and event listener add/remove

### DIFF
--- a/Include/Rocket/Core/Element.h
+++ b/Include/Rocket/Core/Element.h
@@ -490,6 +490,9 @@ public:
 	/// @param[in] listener The listener object to be detached.
 	/// @param[in] in_capture_phase True to detach from the capture phase, false from the bubble phase.
 	void RemoveEventListener(const String& event, EventListener* listener, bool in_capture_phase = false);
+	/// Removes event listeners from this element.
+    /// @param[in] event Event to detach from.
+    void RemoveEventListeners(const String& event);
 	/// Sends an event to this element.
 	/// @param[in] event Name of the event in string form.
 	/// @param[in] parameters The event parameters.

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1045,6 +1045,12 @@ void Element::RemoveEventListener(const String& event, EventListener* listener, 
 	event_dispatcher->DetachEvent(event, listener, in_capture_phase);
 }
 
+// Removes an event listener from this element.
+void Element::RemoveEventListeners(const String& event)
+{
+	event_dispatcher->DetachEvents(event);
+}
+
 // Dispatches the specified event
 bool Element::DispatchEvent(const String& event, const Dictionary& parameters, bool interruptible)
 {

--- a/Source/Core/EventDispatcher.cpp
+++ b/Source/Core/EventDispatcher.cpp
@@ -94,6 +94,28 @@ void EventDispatcher::DetachEvent(const String& type, EventListener* listener, b
 	}
 }
 
+void EventDispatcher::DetachEvents(const String& type)
+{
+	// Look up the event
+	Events::iterator event_itr = events.find(type);
+
+	// Bail if we can't find the event
+	if (event_itr == events.end())
+	{
+		return;
+	}
+
+	// Remove all listeners
+	Listeners::iterator listener_itr = (*event_itr).second.begin();
+	EventListener* listener;
+	while (listener_itr != (*event_itr).second.end())
+	{
+	    listener = (*listener_itr).listener;
+        listener_itr = (*event_itr).second.erase(listener_itr);
+        listener->OnDetach(element);
+	};
+}
+
 // Detaches all events from this dispatcher and all child dispatchers.
 void EventDispatcher::DetachAllEvents()
 {

--- a/Source/Core/EventDispatcher.h
+++ b/Source/Core/EventDispatcher.h
@@ -67,6 +67,10 @@ public:
 	/// @param[in] in_capture_phase Should the listener be notified in the capture phase
 	void DetachEvent(const String& type, EventListener* listener, bool in_capture_phase);
 
+	/// Detaches all listeners from the specified event name
+    /// @param[in] type Type of the event to detach from
+	void DetachEvents(const String& type);
+
 	/// Detaches all events from this dispatcher and all child dispatchers.
 	void DetachAllEvents();
 

--- a/Source/Core/Python/Converters.cpp
+++ b/Source/Core/Python/Converters.cpp
@@ -200,7 +200,9 @@ struct EventListenerFromPython
         if (it != EventListener::active_listeners.end()) {
             return (void*)it->second;
         }
-        else return new EventListener( object );
+        else {
+        return new EventListener( object );
+        }
 	}
 };
 

--- a/Source/Core/Python/ElementInterface.cpp
+++ b/Source/Core/Python/ElementInterface.cpp
@@ -68,6 +68,7 @@ void ElementInterface::InitialisePythonInterface()
 	void (*RemoveEventListener)(Element* element, const char* event, Rocket::Core::Python::EventListener* listener, bool in_capture_phase) = &ElementInterface::RemoveEventListener;
 	void (*AddEventListenerDefault)(Element* element, const char* event, Rocket::Core::Python::EventListener* listener) = &ElementInterface::AddEventListener;
 	void (*RemoveEventListenerDefault)(Element* element, const char* event, Rocket::Core::Python::EventListener* listener) = &ElementInterface::RemoveEventListener;
+	void (*RemoveEventListeners)(Element* element, const char* event) = &ElementInterface::RemoveEventListener;
 
 	// Define the basic element type.
 	class_definitions["Element"] = python::class_< Element, ElementWrapper< Element >, boost::noncopyable >("Element", python::init< const char* >())
@@ -75,6 +76,7 @@ void ElementInterface::InitialisePythonInterface()
 		.def("AddEventListener", AddEventListenerDefault)
 		.def("RemoveEventListener", RemoveEventListener)
 		.def("RemoveEventListener", RemoveEventListenerDefault)
+		.def("RemoveEventListener", RemoveEventListeners)
 		.def("AppendChild", &ElementInterface::AppendChild)
 		.def("Blur", &Element::Blur)
 		.def("Click", &Element::Click)
@@ -207,6 +209,11 @@ void ElementInterface::RemoveEventListener(Element* element, const char* event, 
 void ElementInterface::RemoveEventListener(Element* element, const char* event, EventListener* listener)
 {
 	element->RemoveEventListener(event, listener);
+}
+
+void ElementInterface::RemoveEventListener(Element* element, const char* event)
+{
+	element->RemoveEventListeners(event);
 }
 
 // Override for AppendChild without the non-DOM boolean.

--- a/Source/Core/Python/ElementInterface.h
+++ b/Source/Core/Python/ElementInterface.h
@@ -72,6 +72,8 @@ public:
 	static void AddEventListener(Element* element, const char* event, Rocket::Core::Python::EventListener* listener);
 	/// Override for RemoveEventListener without the third parameter.
     static void RemoveEventListener(Element* element, const char* event, Rocket::Core::Python::EventListener* listener);
+    /// Override for RemoveEventListener by type only
+    static void RemoveEventListener(Element* element, const char* event);
 	/// Override for AppendChild without the non-DOM boolean.
 	static void AppendChild(Element* element, Element* child);
 	/// Dispatches an event.

--- a/Source/Core/Python/EventListener.cpp
+++ b/Source/Core/Python/EventListener.cpp
@@ -44,6 +44,8 @@ EventListener::EventListener(PyObject* object)
 	callable = NULL;
 	element = NULL;
 	global_namespace = NULL;
+	source_object = object;
+	active_listeners[source_object] = this;
 
 	if (PyCallable_Check(object))
 	{
@@ -90,8 +92,6 @@ EventListener::EventListener(PyObject* object)
 		Log::Message(Rocket::Core::Log::LT_ERROR, "Failed to initialise python based event listener. Unknown python object type, should be a callable or a string."); 
 	}
 
-	//
-	active_listeners[object] = this;
 }
 
 EventListener::EventListener(const Rocket::Core::String& code, Element* context)
@@ -107,7 +107,7 @@ EventListener::EventListener(const Rocket::Core::String& code, Element* context)
 EventListener::~EventListener()
 {
 
-    EventListenersMap::iterator it = active_listeners.find(callable);
+    EventListenersMap::iterator it = active_listeners.find(source_object);
     if (it != active_listeners.end()) {
         active_listeners.erase(it);
     }

--- a/Source/Core/Python/EventListener.h
+++ b/Source/Core/Python/EventListener.h
@@ -76,6 +76,9 @@ private:
 	PyObject* callable;
 	PyObject* global_namespace;
 
+	// Used to keep track of event listeners
+	PyObject* source_object;
+
 	// Source code, if any
 	Rocket::Core::String source_code;
 


### PR DESCRIPTION
These changes were tested on the Ignifuga Game Engine and "work for me". This pull allows the user to add and remove attached event listeners, and it exposes a few more methods on the Python Element wrapper.
