### PR TITLE
Set the document global variable when the ElementDocumentWrapper is created

### DIFF
--- a/Source/Core/Python/ElementDocumentWrapper.cpp
+++ b/Source/Core/Python/ElementDocumentWrapper.cpp
@@ -46,6 +46,9 @@ ElementDocumentWrapper::ElementDocumentWrapper(PyObject* self, const char* tag) 
 	PyObject* builtins = PyImport_AddModule("__main__");
 	PyObject* builtins_dict = PyModule_GetDict( builtins);
 	PyDict_Merge(module_namespace, builtins_dict, 0);
+
+	// Insert the document global
+	PyDict_SetItemString(module_namespace, "document", self);
 }
 
 ElementDocumentWrapper::~ElementDocumentWrapper()

--- a/Source/Core/Python/EventListener.cpp
+++ b/Source/Core/Python/EventListener.cpp
@@ -138,7 +138,6 @@ void EventListener::ProcessEvent(Event& event)
 	// Set up the new expected globals
 	PyDict_SetItemString(py_namespace, "event", Rocket::Core::Python::Utilities::MakeObject(&event).ptr());
 	PyDict_SetItemString(py_namespace, "self", Rocket::Core::Python::Utilities::MakeObject(element).ptr());
-	PyDict_SetItemString(py_namespace, "document", Rocket::Core::Python::Utilities::MakeObject(element->GetOwnerDocument()).ptr());
 
 	// Call the bound function
 	PyObject* result = NULL;


### PR DESCRIPTION
Useful to access the document using a global variable named "document"
