### PR TITLE
Fix copy paste error in Element Style Cache

### DIFF
--- a/Source/Core/ElementStyleCache.cpp
+++ b/Source/Core/ElementStyleCache.cpp
@@ -144,7 +144,7 @@ void ElementStyleCache::GetBorderWidthProperties(const Property **o_border_top_w
 	{
 		if (!border_bottom_width)
 			border_bottom_width = style->GetProperty(BORDER_BOTTOM_WIDTH);
-		*o_border_bottom_width = border_top_width;
+		*o_border_bottom_width = border_bottom_width;
 	}
 
 	if (o_border_left_width)


### PR DESCRIPTION
Changing the border-bottom property didn't work since the Element Style Cache stuff was added, turns out there was a copy/paste error.
