### PR TITLE
Fix include paths

### DIFF
--- a/Source/Controls/Controls.cpp
+++ b/Source/Controls/Controls.cpp
@@ -32,10 +32,10 @@
 #include <Rocket/Core/XMLParser.h>
 #include <Rocket/Core/Plugin.h>
 #include <Rocket/Core/Core.h>
-#include "ElementTextSelection.h"
-#include "XMLNodeHandlerDataGrid.h"
-#include "XMLNodeHandlerTabSet.h"
-#include "XMLNodeHandlerTextArea.h"
+#include <Rocket/Controls/ElementTextSelection.h>
+#include <Rocket/Controls/XMLNodeHandlerDataGrid.h>
+#include <Rocket/Controls/XMLNodeHandlerTabSet.h>
+#include <Rocket/Controls/XMLNodeHandlerTextArea.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 
 namespace Rocket {

--- a/Source/Controls/ElementFormControlDataSelect.cpp
+++ b/Source/Controls/ElementFormControlDataSelect.cpp
@@ -29,7 +29,7 @@
 #include <Rocket/Controls/DataQuery.h>
 #include <Rocket/Controls/DataSource.h>
 #include <Rocket/Controls/DataFormatter.h>
-#include "WidgetDropDown.h"
+#include <Rocket/Controls/WidgetDropDown.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/ElementFormControlInput.cpp
+++ b/Source/Controls/ElementFormControlInput.cpp
@@ -27,12 +27,12 @@
 
 #include <Rocket/Controls/ElementFormControlInput.h>
 #include <Rocket/Core/Event.h>
-#include "InputTypeButton.h"
-#include "InputTypeCheckbox.h"
-#include "InputTypeRadio.h"
-#include "InputTypeRange.h"
-#include "InputTypeSubmit.h"
-#include "InputTypeText.h"
+#include <Rocket/Controls/InputTypeButton.h>
+#include <Rocket/Controls/InputTypeCheckbox.h>
+#include <Rocket/Controls/InputTypeRadio.h>
+#include <Rocket/Controls/InputTypeRange.h>
+#include <Rocket/Controls/InputTypeSubmit.h>
+#include <Rocket/Controls/InputTypeText.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/ElementFormControlSelect.cpp
+++ b/Source/Controls/ElementFormControlSelect.cpp
@@ -29,7 +29,7 @@
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/Event.h>
 #include <Rocket/Core/ElementUtilities.h>
-#include "WidgetDropDown.h"
+#include <Rocket/Controls/WidgetDropDown.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/ElementFormControlTextArea.cpp
+++ b/Source/Controls/ElementFormControlTextArea.cpp
@@ -29,7 +29,7 @@
 #include <Rocket/Core/Math.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/ElementText.h>
-#include "WidgetTextInputMultiLine.h"
+#include <Rocket/Controls/WidgetTextInputMultiLine.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/ElementTextSelection.cpp
+++ b/Source/Controls/ElementTextSelection.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "ElementTextSelection.h"
-#include "WidgetTextInput.h"
+#include <Rocket/Controls/ElementTextSelection.h>
+#include <Rocket/Controls/WidgetTextInput.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/InputType.cpp
+++ b/Source/Controls/InputType.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "InputType.h"
+#include <Rocket/Controls/InputType.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 
 namespace Rocket {

--- a/Source/Controls/InputTypeButton.cpp
+++ b/Source/Controls/InputTypeButton.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "InputTypeButton.h"
+#include <Rocket/Controls/InputTypeButton.h>
 #include <Rocket/Controls/ElementForm.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 

--- a/Source/Controls/InputTypeButton.h
+++ b/Source/Controls/InputTypeButton.h
@@ -30,7 +30,7 @@
 
 #include <Rocket/Core/EventListener.h>
 #include <Rocket/Core/ElementDocument.h>
-#include "InputType.h"
+#include <Rocket/Controls/InputType.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/InputTypeCheckbox.cpp
+++ b/Source/Controls/InputTypeCheckbox.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "InputTypeCheckbox.h"
+#include <Rocket/Controls/InputTypeCheckbox.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 
 namespace Rocket {

--- a/Source/Controls/InputTypeCheckbox.h
+++ b/Source/Controls/InputTypeCheckbox.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSINPUTTYPECHECKBOX_H
 #define ROCKETCONTROLSINPUTTYPECHECKBOX_H
 
-#include "InputType.h"
+#include <Rocket/Controls/InputType.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/InputTypeRadio.cpp
+++ b/Source/Controls/InputTypeRadio.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "InputTypeRadio.h"
+#include <Rocket/Controls/InputTypeRadio.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Controls/ElementForm.h>

--- a/Source/Controls/InputTypeRadio.h
+++ b/Source/Controls/InputTypeRadio.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSINPUTTYPERADIO_H
 #define ROCKETCONTROLSINPUTTYPERADIO_H
 
-#include "InputType.h"
+#include <Rocket/Controls/InputType.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/InputTypeRange.cpp
+++ b/Source/Controls/InputTypeRange.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "InputTypeRange.h"
-#include "WidgetSliderInput.h"
+#include <Rocket/Controls/InputTypeRange.h>
+#include <Rocket/Controls/WidgetSliderInput.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 
 namespace Rocket {

--- a/Source/Controls/InputTypeRange.h
+++ b/Source/Controls/InputTypeRange.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSINPUTTYPERANGE_H
 #define ROCKETCONTROLSINPUTTYPERANGE_H
 
-#include "InputType.h"
+#include <Rocket/Controls/InputType.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/InputTypeSubmit.cpp
+++ b/Source/Controls/InputTypeSubmit.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "InputTypeSubmit.h"
+#include <Rocket/Controls/InputTypeSubmit.h>
 #include <Rocket/Controls/ElementForm.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 

--- a/Source/Controls/InputTypeSubmit.h
+++ b/Source/Controls/InputTypeSubmit.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSINPUTTYPESUBMIT_H
 #define ROCKETCONTROLSINPUTTYPESUBMIT_H
 
-#include "InputType.h"
+#include <Rocket/Controls/InputType.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/InputTypeText.cpp
+++ b/Source/Controls/InputTypeText.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "InputTypeText.h"
+#include <Rocket/Controls/InputTypeText.h>
 #include <Rocket/Core/ElementUtilities.h>
-#include "WidgetTextInputSingleLine.h"
-#include "WidgetTextInputSingleLinePassword.h"
+#include <Rocket/Controls/WidgetTextInputSingleLine.h>
+#include <Rocket/Controls/WidgetTextInputSingleLinePassword.h>
 #include <Rocket/Controls/ElementFormControlInput.h>
 
 namespace Rocket {

--- a/Source/Controls/InputTypeText.h
+++ b/Source/Controls/InputTypeText.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSINPUTTYPETEXT_H
 #define ROCKETCONTROLSINPUTTYPETEXT_H
 
-#include "InputType.h"
+#include <Rocket/Controls/InputType.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/Python/DataFormatterWrapper.cpp
+++ b/Source/Controls/Python/DataFormatterWrapper.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DataFormatterWrapper.h"
+#include <Rocket/Controls/Python/precompiled.h>
+#include <Rocket/Controls/Python/DataFormatterWrapper.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/Python/DataGridRowProxy.cpp
+++ b/Source/Controls/Python/DataGridRowProxy.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DataGridRowProxy.h"
+#include <Rocket/Controls/Python/precompiled.h>
+#include <Rocket/Controls/Python/DataGridRowProxy.h>
 #include <Rocket/Core/Python/NameIndexInterface.h>
 #include <Rocket/Core/Python/Utilities.h>
 #include <Rocket/Core.h>

--- a/Source/Controls/Python/DataSourceWrapper.cpp
+++ b/Source/Controls/Python/DataSourceWrapper.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DataSourceWrapper.h"
+#include <Rocket/Controls/Python/precompiled.h>
+#include <Rocket/Controls/Python/DataSourceWrapper.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/Python/Utilities.h>
 
@@ -35,7 +35,7 @@ namespace Controls {
 namespace Python {
 
 // Returns the string representation of a python class name
-static Core::String GetPythonClassName(PyObject* object)
+extern Core::String GetPythonClassName(PyObject* object)
 {
 	Core::String full_name;
 

--- a/Source/Controls/Python/DataSourceWrapper.h
+++ b/Source/Controls/Python/DataSourceWrapper.h
@@ -36,6 +36,8 @@ namespace Rocket {
 namespace Controls {
 namespace Python {
 
+extern Core::String GetPythonClassName(PyObject* object);
+
 /**
 	Python DataSource Wrapper
 

--- a/Source/Controls/Python/ElementInterface.cpp
+++ b/Source/Controls/Python/ElementInterface.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementInterface.h"
+#include <Rocket/Controls/Python/precompiled.h>
+#include <Rocket/Controls/Python/ElementInterface.h>
 #include <Rocket/Core/Python/ConverterScriptObject.h>
 #include <Rocket/Core/Factory.h>
 #include <Rocket/Core/Python/ElementInstancer.h>
@@ -41,8 +41,8 @@
 #include <Rocket/Controls/ElementFormControlSelect.h>
 #include <Rocket/Controls/ElementFormControlTextArea.h>
 #include <Rocket/Controls/ElementTabSet.h>
-#include "SelectOptionProxy.h"
-#include "DataGridRowProxy.h"
+#include <Rocket/Controls/Python/SelectOptionProxy.h>
+#include <Rocket/Controls/Python/DataGridRowProxy.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/Python/ElementInterface.h
+++ b/Source/Controls/Python/ElementInterface.h
@@ -28,8 +28,8 @@
 #ifndef ROCKETCONTROLSPYTHONELEMENTINTERFACE_H
 #define ROCKETCONTROLSPYTHONELEMENTINTERFACE_H
 
-#include "SelectOptionProxy.h"
-#include "DataGridRowProxy.h"
+#include <Rocket/Controls/Python/SelectOptionProxy.h>
+#include <Rocket/Controls/Python/DataGridRowProxy.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/Python/Module.cpp
+++ b/Source/Controls/Python/Module.cpp
@@ -25,14 +25,14 @@
  *
  */
 
-#include "precompiled.h"
-#include "Module.h"
+#include <Rocket/Controls/Python/precompiled.h>
+#include <Rocket/Controls/Python/Module.h>
 #include <Rocket/Core/Python/Python.h>
 #include <Rocket/Core/Python/ConverterScriptObject.h>
 #include <Rocket/Controls/DataSource.h>
-#include "ElementInterface.h"
-#include "DataFormatterWrapper.h"
-#include "DataSourceWrapper.h"
+#include <Rocket/Controls/Python/ElementInterface.h>
+#include <Rocket/Controls/Python/DataFormatterWrapper.h>
+#include <Rocket/Controls/Python/DataSourceWrapper.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/Python/SelectOptionProxy.cpp
+++ b/Source/Controls/Python/SelectOptionProxy.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "SelectOptionProxy.h"
+#include <Rocket/Controls/Python/precompiled.h>
+#include <Rocket/Controls/Python/SelectOptionProxy.h>
 #include <Rocket/Core/Element.h>
 
 namespace Rocket {

--- a/Source/Controls/Python/precompiled.cpp
+++ b/Source/Controls/Python/precompiled.cpp
@@ -25,4 +25,4 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Controls/Python/precompiled.h>

--- a/Source/Controls/WidgetDropDown.cpp
+++ b/Source/Controls/WidgetDropDown.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "WidgetDropDown.h"
+#include <Rocket/Controls/WidgetDropDown.h>
 #include <Rocket/Core/Math.h>
 #include <Rocket/Core/Factory.h>
 #include <Rocket/Core/ElementUtilities.h>

--- a/Source/Controls/WidgetSlider.cpp
+++ b/Source/Controls/WidgetSlider.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "WidgetSlider.h"
+#include <Rocket/Controls/WidgetSlider.h>
 #include <Rocket/Core.h>
 #include <Rocket/Controls/ElementFormControl.h>
 

--- a/Source/Controls/WidgetSliderInput.cpp
+++ b/Source/Controls/WidgetSliderInput.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "WidgetSliderInput.h"
+#include <Rocket/Controls/WidgetSliderInput.h>
 #include <Rocket/Core/Math.h>
 #include <Rocket/Core/Element.h>
 

--- a/Source/Controls/WidgetSliderInput.h
+++ b/Source/Controls/WidgetSliderInput.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSWIDGETSLIDERINPUT_H
 #define ROCKETCONTROLSWIDGETSLIDERINPUT_H
 
-#include "WidgetSlider.h"
+#include <Rocket/Controls/WidgetSlider.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/WidgetTextInput.cpp
+++ b/Source/Controls/WidgetTextInput.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "WidgetTextInput.h"
-#include "ElementTextSelection.h"
+#include <Rocket/Controls/WidgetTextInput.h>
+#include <Rocket/Controls/ElementTextSelection.h>
 #include <Rocket/Core.h>
 #include <Rocket/Controls/ElementFormControl.h>
 #include <Rocket/Controls/Clipboard.h>

--- a/Source/Controls/WidgetTextInputMultiLine.cpp
+++ b/Source/Controls/WidgetTextInputMultiLine.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "WidgetTextInputMultiLine.h"
+#include <Rocket/Controls/WidgetTextInputMultiLine.h>
 #include <Rocket/Core/Dictionary.h>
 #include <Rocket/Core/ElementText.h>
 

--- a/Source/Controls/WidgetTextInputMultiLine.h
+++ b/Source/Controls/WidgetTextInputMultiLine.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSWIDGETTEXTINPUTMULTILINE_H
 #define ROCKETCONTROLSWIDGETTEXTINPUTMULTILINE_H
 
-#include "WidgetTextInput.h"
+#include <Rocket/Controls/WidgetTextInput.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/WidgetTextInputSingleLine.cpp
+++ b/Source/Controls/WidgetTextInputSingleLine.cpp
@@ -27,7 +27,7 @@
 
 #include <Rocket/Core/Dictionary.h>
 #include <Rocket/Core/ElementText.h>
-#include "WidgetTextInputSingleLine.h"
+#include <Rocket/Controls/WidgetTextInputSingleLine.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/WidgetTextInputSingleLine.h
+++ b/Source/Controls/WidgetTextInputSingleLine.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINE_H
 #define ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINE_H
 
-#include "WidgetTextInput.h"
+#include <Rocket/Controls/WidgetTextInput.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/WidgetTextInputSingleLinePassword.cpp
+++ b/Source/Controls/WidgetTextInputSingleLinePassword.cpp
@@ -26,7 +26,7 @@
  */
 
 #include <Rocket/Core/ElementText.h>
-#include "WidgetTextInputSingleLinePassword.h"
+#include <Rocket/Controls/WidgetTextInputSingleLinePassword.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/WidgetTextInputSingleLinePassword.h
+++ b/Source/Controls/WidgetTextInputSingleLinePassword.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINEPASSWORD_H
 #define ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINEPASSWORD_H
 
-#include "WidgetTextInputSingleLine.h"
+#include <Rocket/Controls/WidgetTextInputSingleLine.h>
 
 namespace Rocket {
 namespace Controls {

--- a/Source/Controls/XMLNodeHandlerDataGrid.cpp
+++ b/Source/Controls/XMLNodeHandlerDataGrid.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "XMLNodeHandlerDataGrid.h"
+#include <Rocket/Controls/XMLNodeHandlerDataGrid.h>
 #include <Rocket/Core/StreamMemory.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/Factory.h>

--- a/Source/Controls/XMLNodeHandlerTabSet.cpp
+++ b/Source/Controls/XMLNodeHandlerTabSet.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "XMLNodeHandlerTabSet.h"
+#include <Rocket/Controls/XMLNodeHandlerTabSet.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/Factory.h>
 #include <Rocket/Core/XMLParser.h>

--- a/Source/Controls/XMLNodeHandlerTextArea.cpp
+++ b/Source/Controls/XMLNodeHandlerTextArea.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "XMLNodeHandlerTextArea.h"
+#include <Rocket/Controls/XMLNodeHandlerTextArea.h>
 #include <Rocket/Core.h>
 #include <Rocket/Controls/ElementFormControlTextArea.h>
 

--- a/Source/Core/BaseXMLParser.cpp
+++ b/Source/Core/BaseXMLParser.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/BaseXMLParser.h>
 
 namespace Rocket {

--- a/Source/Core/Box.cpp
+++ b/Source/Core/Box.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Box.h>
 
 namespace Rocket {

--- a/Source/Core/Clock.cpp
+++ b/Source/Core/Clock.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "Clock.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/Clock.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -25,12 +25,12 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core.h>
-#include "EventDispatcher.h"
-#include "EventIterators.h"
-#include "PluginRegistry.h"
-#include "StreamFile.h"
+#include <Rocket/Core/EventDispatcher.h>
+#include <Rocket/Core/EventIterators.h>
+#include <Rocket/Core/PluginRegistry.h>
+#include <Rocket/Core/StreamFile.h>
 #include <Rocket/Core/StreamMemory.h>
 #include <algorithm>
 #include <iterator>

--- a/Source/Core/ContextInstancer.cpp
+++ b/Source/Core/ContextInstancer.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ContextInstancer.h>
 
 namespace Rocket {

--- a/Source/Core/ContextInstancerDefault.cpp
+++ b/Source/Core/ContextInstancerDefault.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ContextInstancerDefault.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ContextInstancerDefault.h>
 #include <Rocket/Core/Context.h>
 
 namespace Rocket {

--- a/Source/Core/ConvolutionFilter.cpp
+++ b/Source/Core/ConvolutionFilter.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ConvolutionFilter.h>
 
 namespace Rocket {

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -25,15 +25,15 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core.h>
 #include <algorithm>
-#include "FileInterfaceDefault.h"
-#include "GeometryDatabase.h"
-#include "PluginRegistry.h"
-#include "StyleSheetFactory.h"
-#include "TemplateCache.h"
-#include "TextureDatabase.h"
+#include <Rocket/Core/FileInterfaceDefault.h>
+#include <Rocket/Core/GeometryDatabase.h>
+#include <Rocket/Core/PluginRegistry.h>
+#include <Rocket/Core/StyleSheetFactory.h>
+#include <Rocket/Core/TemplateCache.h>
+#include <Rocket/Core/TextureDatabase.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Decorator.cpp
+++ b/Source/Core/Decorator.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Decorator.h>
-#include "TextureDatabase.h"
-#include "TextureResource.h"
+#include <Rocket/Core/TextureDatabase.h>
+#include <Rocket/Core/TextureResource.h>
 #include <Rocket/Core/DecoratorInstancer.h>
 #include <Rocket/Core/PropertyDefinition.h>
 

--- a/Source/Core/DecoratorInstancer.cpp
+++ b/Source/Core/DecoratorInstancer.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/DecoratorInstancer.h>
 
 namespace Rocket {

--- a/Source/Core/DecoratorNone.cpp
+++ b/Source/Core/DecoratorNone.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorNone.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorNone.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorNoneInstancer.cpp
+++ b/Source/Core/DecoratorNoneInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorNoneInstancer.h"
-#include "DecoratorNone.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorNoneInstancer.h>
+#include <Rocket/Core/DecoratorNone.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiled.cpp
+++ b/Source/Core/DecoratorTiled.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiled.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiled.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/DecoratorTiledBox.cpp
+++ b/Source/Core/DecoratorTiledBox.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledBox.h"
-#include "TextureResource.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledBox.h>
+#include <Rocket/Core/TextureResource.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Geometry.h>
 

--- a/Source/Core/DecoratorTiledBox.h
+++ b/Source/Core/DecoratorTiledBox.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDBOX_H
 #define ROCKETCOREDECORATORTILEDBOX_H
 
-#include "DecoratorTiled.h"
+#include <Rocket/Core/DecoratorTiled.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledBoxInstancer.cpp
+++ b/Source/Core/DecoratorTiledBoxInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledBoxInstancer.h"
-#include "DecoratorTiledBox.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledBoxInstancer.h>
+#include <Rocket/Core/DecoratorTiledBox.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledBoxInstancer.h
+++ b/Source/Core/DecoratorTiledBoxInstancer.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDBOXINSTANCER_H
 #define ROCKETCOREDECORATORTILEDBOXINSTANCER_H
 
-#include "DecoratorTiledInstancer.h"
+#include <Rocket/Core/DecoratorTiledInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledHorizontal.cpp
+++ b/Source/Core/DecoratorTiledHorizontal.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledHorizontal.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledHorizontal.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Geometry.h>
 #include <Rocket/Core/Texture.h>

--- a/Source/Core/DecoratorTiledHorizontal.h
+++ b/Source/Core/DecoratorTiledHorizontal.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDHORIZONTAL_H
 #define ROCKETCOREDECORATORTILEDHORIZONTAL_H
 
-#include "DecoratorTiled.h"
+#include <Rocket/Core/DecoratorTiled.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledHorizontalInstancer.cpp
+++ b/Source/Core/DecoratorTiledHorizontalInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledHorizontalInstancer.h"
-#include "DecoratorTiledHorizontal.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledHorizontalInstancer.h>
+#include <Rocket/Core/DecoratorTiledHorizontal.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledHorizontalInstancer.h
+++ b/Source/Core/DecoratorTiledHorizontalInstancer.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDHORIZONTALINSTANCER_H
 #define ROCKETCOREDECORATORTILEDHORIZONTALINSTANCER_H
 
-#include "DecoratorTiledInstancer.h"
+#include <Rocket/Core/DecoratorTiledInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledImage.cpp
+++ b/Source/Core/DecoratorTiledImage.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledImage.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledImage.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Geometry.h>
 #include <Rocket/Core/GeometryUtilities.h>

--- a/Source/Core/DecoratorTiledImage.h
+++ b/Source/Core/DecoratorTiledImage.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDIMAGE_H
 #define ROCKETCOREDECORATORTILEDIMAGE_H
 
-#include "DecoratorTiled.h"
+#include <Rocket/Core/DecoratorTiled.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledImageInstancer.cpp
+++ b/Source/Core/DecoratorTiledImageInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledImageInstancer.h"
-#include "DecoratorTiledImage.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledImageInstancer.h>
+#include <Rocket/Core/DecoratorTiledImage.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledImageInstancer.h
+++ b/Source/Core/DecoratorTiledImageInstancer.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDIMAGEINSTANCER_H
 #define ROCKETCOREDECORATORTILEDIMAGEINSTANCER_H
 
-#include "DecoratorTiledInstancer.h"
+#include <Rocket/Core/DecoratorTiledInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledInstancer.cpp
+++ b/Source/Core/DecoratorTiledInstancer.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledInstancer.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledInstancer.h>
 #include <Rocket/Core/PropertyDefinition.h>
 
 namespace Rocket {

--- a/Source/Core/DecoratorTiledInstancer.h
+++ b/Source/Core/DecoratorTiledInstancer.h
@@ -29,7 +29,7 @@
 #define ROCKETCOREDECORATORTILEDINSTANCER_H
 
 #include <Rocket/Core/DecoratorInstancer.h>
-#include "DecoratorTiled.h"
+#include <Rocket/Core/DecoratorTiled.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledVertical.cpp
+++ b/Source/Core/DecoratorTiledVertical.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledVertical.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledVertical.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Geometry.h>
 #include <Rocket/Core/GeometryUtilities.h>

--- a/Source/Core/DecoratorTiledVertical.h
+++ b/Source/Core/DecoratorTiledVertical.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDVERTICAL_H
 #define ROCKETCOREDECORATORTILEDVERTICAL_H
 
-#include "DecoratorTiled.h"
+#include <Rocket/Core/DecoratorTiled.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledVerticalInstancer.cpp
+++ b/Source/Core/DecoratorTiledVerticalInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "DecoratorTiledVertical.h"
-#include "DecoratorTiledVerticalInstancer.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DecoratorTiledVertical.h>
+#include <Rocket/Core/DecoratorTiledVerticalInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/DecoratorTiledVerticalInstancer.h
+++ b/Source/Core/DecoratorTiledVerticalInstancer.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREDECORATORTILEDVERTICALINSTANCER_H
 #define ROCKETCOREDECORATORTILEDVERTICALINSTANCER_H
 
-#include "DecoratorTiledInstancer.h"
+#include <Rocket/Core/DecoratorTiledInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Dictionary.cpp
+++ b/Source/Core/Dictionary.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Dictionary.h>
 
 /* NOTE: This is dictionary implementation is copied from PYTHON 

--- a/Source/Core/DocumentHeader.cpp
+++ b/Source/Core/DocumentHeader.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "DocumentHeader.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/DocumentHeader.h>
+#include <Rocket/Core/XMLParseTools.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -25,21 +25,21 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Dictionary.h>
 #include <algorithm>
-#include "ElementBackground.h"
-#include "ElementBorder.h"
-#include "ElementDefinition.h"
-#include "ElementStyle.h"
-#include "EventDispatcher.h"
-#include "ElementDecoration.h"
-#include "FontFaceHandle.h"
-#include "LayoutEngine.h"
-#include "PluginRegistry.h"
-#include "StyleSheetParser.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/ElementBackground.h>
+#include <Rocket/Core/ElementBorder.h>
+#include <Rocket/Core/ElementDefinition.h>
+#include <Rocket/Core/ElementStyle.h>
+#include <Rocket/Core/EventDispatcher.h>
+#include <Rocket/Core/ElementDecoration.h>
+#include <Rocket/Core/FontFaceHandle.h>
+#include <Rocket/Core/LayoutEngine.h>
+#include <Rocket/Core/PluginRegistry.h>
+#include <Rocket/Core/StyleSheetParser.h>
+#include <Rocket/Core/XMLParseTools.h>
 #include <Rocket/Core/Core.h>
 
 namespace Rocket {

--- a/Source/Core/ElementBackground.cpp
+++ b/Source/Core/ElementBackground.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementBackground.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementBackground.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/GeometryUtilities.h>
 #include <Rocket/Core/Property.h>

--- a/Source/Core/ElementBorder.cpp
+++ b/Source/Core/ElementBorder.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementBorder.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementBorder.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Property.h>
 

--- a/Source/Core/ElementDecoration.cpp
+++ b/Source/Core/ElementDecoration.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementDecoration.h"
-#include "ElementDefinition.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementDecoration.h>
+#include <Rocket/Core/ElementDefinition.h>
 #include <Rocket/Core/Decorator.h>
 #include <Rocket/Core/Element.h>
 

--- a/Source/Core/ElementDefinition.cpp
+++ b/Source/Core/ElementDefinition.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementDefinition.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementDefinition.h>
 #include <Rocket/Core/Decorator.h>
 #include <Rocket/Core/Factory.h>
 #include <Rocket/Core/FontDatabase.h>

--- a/Source/Core/ElementDefinition.h
+++ b/Source/Core/ElementDefinition.h
@@ -33,7 +33,7 @@
 #include <map>
 #include <set>
 #include <Rocket/Core/FontEffect.h>
-#include "StyleSheetNode.h"
+#include <Rocket/Core/StyleSheetNode.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -25,19 +25,19 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ElementDocument.h>
 #include <Rocket/Core/StreamMemory.h>
 #include <Rocket/Core.h>
-#include "DocumentHeader.h"
-#include "ElementStyle.h"
-#include "EventDispatcher.h"
-#include "LayoutEngine.h"
-#include "StreamFile.h"
-#include "StyleSheetFactory.h"
-#include "Template.h"
-#include "TemplateCache.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/DocumentHeader.h>
+#include <Rocket/Core/ElementStyle.h>
+#include <Rocket/Core/EventDispatcher.h>
+#include <Rocket/Core/LayoutEngine.h>
+#include <Rocket/Core/StreamFile.h>
+#include <Rocket/Core/StyleSheetFactory.h>
+#include <Rocket/Core/Template.h>
+#include <Rocket/Core/TemplateCache.h>
+#include <Rocket/Core/XMLParseTools.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/ElementHandle.cpp
+++ b/Source/Core/ElementHandle.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementHandle.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementHandle.h>
 #include <Rocket/Core/ElementDocument.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/Property.h>

--- a/Source/Core/ElementImage.cpp
+++ b/Source/Core/ElementImage.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementImage.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementImage.h>
 #include <Rocket/Core.h>
-#include "TextureDatabase.h"
-#include "TextureResource.h"
+#include <Rocket/Core/TextureDatabase.h>
+#include <Rocket/Core/TextureResource.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/ElementInstancer.cpp
+++ b/Source/Core/ElementInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ElementInstancer.h>
-#include "XMLParseTools.h"
+#include <Rocket/Core/XMLParseTools.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/ElementReference.cpp
+++ b/Source/Core/ElementReference.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ElementReference.h>
 #include <Rocket/Core/Element.h>
 

--- a/Source/Core/ElementScroll.cpp
+++ b/Source/Core/ElementScroll.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ElementScroll.h>
-#include "LayoutEngine.h"
-#include "WidgetSliderScroll.h"
+#include <Rocket/Core/LayoutEngine.h>
+#include <Rocket/Core/WidgetSliderScroll.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/Event.h>

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementStyle.h"
-#include "ElementStyleCache.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementStyle.h>
+#include <Rocket/Core/ElementStyleCache.h>
 #include <algorithm>
 #include <Rocket/Core/ElementDocument.h>
 #include <Rocket/Core/ElementUtilities.h>
@@ -36,11 +36,11 @@
 #include <Rocket/Core/PropertyDefinition.h>
 #include <Rocket/Core/PropertyDictionary.h>
 #include <Rocket/Core/StyleSheetSpecification.h>
-#include "ElementBackground.h"
-#include "ElementBorder.h"
-#include "ElementDecoration.h"
-#include "ElementDefinition.h"
-#include "FontFaceHandle.h"
+#include <Rocket/Core/ElementBackground.h>
+#include <Rocket/Core/ElementBorder.h>
+#include <Rocket/Core/ElementDecoration.h>
+#include <Rocket/Core/ElementDefinition.h>
+#include <Rocket/Core/FontFaceHandle.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/ElementStyle.h
+++ b/Source/Core/ElementStyle.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREELEMENTSTYLE_H
 #define ROCKETCOREELEMENTSTYLE_H
 
-#include "ElementDefinition.h"
+#include <Rocket/Core/ElementDefinition.h>
 #include <Rocket/Core/Types.h>
 
 namespace Rocket {

--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ElementText.h>
 
 namespace Rocket {

--- a/Source/Core/ElementTextDefault.cpp
+++ b/Source/Core/ElementTextDefault.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementTextDefault.h"
-#include "ElementDefinition.h"
-#include "ElementStyle.h"
-#include "FontFaceHandle.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/ElementTextDefault.h>
+#include <Rocket/Core/ElementDefinition.h>
+#include <Rocket/Core/ElementStyle.h>
+#include <Rocket/Core/FontFaceHandle.h>
 #include <Rocket/Core/ElementDocument.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/Event.h>

--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <queue>
-#include "FontFaceHandle.h"
-#include "LayoutEngine.h"
+#include <Rocket/Core/FontFaceHandle.h>
+#include <Rocket/Core/LayoutEngine.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/Event.cpp
+++ b/Source/Core/Event.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Event.h>
 #include <Rocket/Core/EventInstancer.h>
 

--- a/Source/Core/EventDispatcher.cpp
+++ b/Source/Core/EventDispatcher.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "EventDispatcher.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/EventDispatcher.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Event.h>
 #include <Rocket/Core/EventListener.h>

--- a/Source/Core/EventInstancer.cpp
+++ b/Source/Core/EventInstancer.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/EventInstancer.h>
 
 namespace Rocket {

--- a/Source/Core/EventInstancerDefault.cpp
+++ b/Source/Core/EventInstancerDefault.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "EventInstancerDefault.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/EventInstancerDefault.h>
 #include <Rocket/Core/Event.h>
 
 namespace Rocket {

--- a/Source/Core/EventListenerInstancer.cpp
+++ b/Source/Core/EventListenerInstancer.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/EventListenerInstancer.h>
 
 namespace Rocket {

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -25,31 +25,31 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core.h>
 #include <Rocket/Core/StreamMemory.h>
-#include "ContextInstancerDefault.h"
-#include "DecoratorNoneInstancer.h"
-#include "DecoratorTiledBoxInstancer.h"
-#include "DecoratorTiledHorizontalInstancer.h"
-#include "DecoratorTiledImageInstancer.h"
-#include "DecoratorTiledVerticalInstancer.h"
-#include "ElementHandle.h"
-#include "ElementImage.h"
-#include "ElementTextDefault.h"
-#include "EventInstancerDefault.h"
-#include "FontEffectNoneInstancer.h"
-#include "FontEffectOutlineInstancer.h"
-#include "FontEffectShadowInstancer.h"
-#include "PluginRegistry.h"
-#include "PropertyParserColour.h"
-#include "StreamFile.h"
-#include "StyleSheetFactory.h"
-#include "XMLNodeHandlerBody.h"
-#include "XMLNodeHandlerDefault.h"
-#include "XMLNodeHandlerHead.h"
-#include "XMLNodeHandlerTemplate.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/ContextInstancerDefault.h>
+#include <Rocket/Core/DecoratorNoneInstancer.h>
+#include <Rocket/Core/DecoratorTiledBoxInstancer.h>
+#include <Rocket/Core/DecoratorTiledHorizontalInstancer.h>
+#include <Rocket/Core/DecoratorTiledImageInstancer.h>
+#include <Rocket/Core/DecoratorTiledVerticalInstancer.h>
+#include <Rocket/Core/ElementHandle.h>
+#include <Rocket/Core/ElementImage.h>
+#include <Rocket/Core/ElementTextDefault.h>
+#include <Rocket/Core/EventInstancerDefault.h>
+#include <Rocket/Core/FontEffectNoneInstancer.h>
+#include <Rocket/Core/FontEffectOutlineInstancer.h>
+#include <Rocket/Core/FontEffectShadowInstancer.h>
+#include <Rocket/Core/PluginRegistry.h>
+#include <Rocket/Core/PropertyParserColour.h>
+#include <Rocket/Core/StreamFile.h>
+#include <Rocket/Core/StyleSheetFactory.h>
+#include <Rocket/Core/XMLNodeHandlerBody.h>
+#include <Rocket/Core/XMLNodeHandlerDefault.h>
+#include <Rocket/Core/XMLNodeHandlerHead.h>
+#include <Rocket/Core/XMLNodeHandlerTemplate.h>
+#include <Rocket/Core/XMLParseTools.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FileInterface.cpp
+++ b/Source/Core/FileInterface.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/FileInterface.h>
 
 namespace Rocket {

--- a/Source/Core/FileInterfaceDefault.cpp
+++ b/Source/Core/FileInterfaceDefault.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "FileInterfaceDefault.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FileInterfaceDefault.h>
 
 #ifndef ROCKET_NO_FILE_INTERFACE_DEFAULT
 

--- a/Source/Core/FontDatabase.cpp
+++ b/Source/Core/FontDatabase.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/FontDatabase.h>
-#include "FontFamily.h"
+#include <Rocket/Core/FontFamily.h>
 #include <Rocket/Core.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H

--- a/Source/Core/FontEffect.cpp
+++ b/Source/Core/FontEffect.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/FontEffect.h>
 #include <Rocket/Core/FontDatabase.h>
 #include <Rocket/Core/FontEffectInstancer.h>

--- a/Source/Core/FontEffectInstancer.cpp
+++ b/Source/Core/FontEffectInstancer.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/FontEffectInstancer.h>
 
 namespace Rocket {

--- a/Source/Core/FontEffectNone.cpp
+++ b/Source/Core/FontEffectNone.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontEffectNone.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontEffectNone.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontEffectNoneInstancer.cpp
+++ b/Source/Core/FontEffectNoneInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontEffectNoneInstancer.h"
-#include "FontEffectNone.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontEffectNoneInstancer.h>
+#include <Rocket/Core/FontEffectNone.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontEffectOutline.cpp
+++ b/Source/Core/FontEffectOutline.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontEffectOutline.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontEffectOutline.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontEffectOutlineInstancer.cpp
+++ b/Source/Core/FontEffectOutlineInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontEffectOutlineInstancer.h"
-#include "FontEffectOutline.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontEffectOutlineInstancer.h>
+#include <Rocket/Core/FontEffectOutline.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontEffectShadow.cpp
+++ b/Source/Core/FontEffectShadow.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontEffectShadow.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontEffectShadow.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontEffectShadowInstancer.cpp
+++ b/Source/Core/FontEffectShadowInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontEffectShadowInstancer.h"
-#include "FontEffectShadow.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontEffectShadowInstancer.h>
+#include <Rocket/Core/FontEffectShadow.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontFace.cpp
+++ b/Source/Core/FontFace.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontFace.h"
-#include "FontFaceHandle.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontFace.h>
+#include <Rocket/Core/FontFaceHandle.h>
 #include <Rocket/Core/Log.h>
 
 namespace Rocket {

--- a/Source/Core/FontFaceHandle.cpp
+++ b/Source/Core/FontFaceHandle.cpp
@@ -25,12 +25,12 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontFaceHandle.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontFaceHandle.h>
 #include <algorithm>
 #include <Rocket/Core.h>
-#include "FontFaceLayer.h"
-#include "TextureLayout.h"
+#include <Rocket/Core/FontFaceLayer.h>
+#include <Rocket/Core/TextureLayout.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontFaceHandle.h
+++ b/Source/Core/FontFaceHandle.h
@@ -29,7 +29,7 @@
 #define ROCKETCOREFONTFACEHANDLE_H
 
 #include <Rocket/Core/ReferenceCountable.h>
-#include "UnicodeRange.h"
+#include <Rocket/Core/UnicodeRange.h>
 #include <Rocket/Core/Font.h>
 #include <Rocket/Core/FontEffect.h>
 #include <Rocket/Core/FontGlyph.h>

--- a/Source/Core/FontFaceLayer.cpp
+++ b/Source/Core/FontFaceLayer.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontFaceLayer.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontFaceLayer.h>
 #include <Rocket/Core/Core.h>
-#include "FontFaceHandle.h"
+#include <Rocket/Core/FontFaceHandle.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontFaceLayer.h
+++ b/Source/Core/FontFaceLayer.h
@@ -33,7 +33,7 @@
 #include <Rocket/Core/GeometryUtilities.h>
 #include <Rocket/Core/String.h>
 #include <Rocket/Core/Texture.h>
-#include "TextureLayout.h"
+#include <Rocket/Core/TextureLayout.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/FontFamily.cpp
+++ b/Source/Core/FontFamily.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "FontFamily.h"
-#include "FontFace.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/FontFamily.h>
+#include <Rocket/Core/FontFace.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Geometry.cpp
+++ b/Source/Core/Geometry.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Geometry.h>
 #include <Rocket/Core.h>
-#include "GeometryDatabase.h"
+#include <Rocket/Core/GeometryDatabase.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/GeometryDatabase.cpp
+++ b/Source/Core/GeometryDatabase.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "GeometryDatabase.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/GeometryDatabase.h>
 #include <Rocket/Core/Geometry.h>
 
 namespace Rocket {

--- a/Source/Core/GeometryUtilities.cpp
+++ b/Source/Core/GeometryUtilities.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/GeometryUtilities.h>
 
 namespace Rocket {

--- a/Source/Core/LayoutBlockBox.cpp
+++ b/Source/Core/LayoutBlockBox.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
-#include "LayoutBlockBox.h"
-#include "LayoutBlockBoxSpace.h"
-#include "LayoutEngine.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/LayoutBlockBox.h>
+#include <Rocket/Core/LayoutBlockBoxSpace.h>
+#include <Rocket/Core/LayoutEngine.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/ElementScroll.h>

--- a/Source/Core/LayoutBlockBox.h
+++ b/Source/Core/LayoutBlockBox.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORELAYOUTBLOCKBOX_H
 #define ROCKETCORELAYOUTBLOCKBOX_H
 
-#include "LayoutLineBox.h"
+#include <Rocket/Core/LayoutLineBox.h>
 #include <Rocket/Core/Box.h>
 #include <Rocket/Core/Types.h>
 

--- a/Source/Core/LayoutBlockBoxSpace.cpp
+++ b/Source/Core/LayoutBlockBoxSpace.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
-#include "LayoutBlockBoxSpace.h"
-#include "LayoutBlockBox.h"
-#include "LayoutEngine.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/LayoutBlockBoxSpace.h>
+#include <Rocket/Core/LayoutBlockBox.h>
+#include <Rocket/Core/LayoutEngine.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/ElementScroll.h>
 #include <Rocket/Core/StyleSheetKeywords.h>

--- a/Source/Core/LayoutEngine.cpp
+++ b/Source/Core/LayoutEngine.cpp
@@ -25,12 +25,12 @@
  *
  */
 
-#include "precompiled.h"
-#include "LayoutEngine.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/LayoutEngine.h>
 #include <Rocket/Core/Math.h>
-#include "Pool.h"
-#include "LayoutBlockBoxSpace.h"
-#include "LayoutInlineBoxText.h"
+#include <Rocket/Core/Pool.h>
+#include <Rocket/Core/LayoutBlockBoxSpace.h>
+#include <Rocket/Core/LayoutInlineBoxText.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/ElementScroll.h>
 #include <Rocket/Core/ElementText.h>

--- a/Source/Core/LayoutEngine.h
+++ b/Source/Core/LayoutEngine.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORELAYOUTENGINE_H
 #define ROCKETCORELAYOUTENGINE_H
 
-#include "LayoutBlockBox.h"
+#include <Rocket/Core/LayoutBlockBox.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/LayoutInlineBox.cpp
+++ b/Source/Core/LayoutInlineBox.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "LayoutInlineBox.h"
-#include "FontFaceHandle.h"
-#include "LayoutBlockBox.h"
-#include "LayoutEngine.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/LayoutInlineBox.h>
+#include <Rocket/Core/FontFaceHandle.h>
+#include <Rocket/Core/LayoutBlockBox.h>
+#include <Rocket/Core/LayoutEngine.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/Property.h>

--- a/Source/Core/LayoutInlineBoxText.cpp
+++ b/Source/Core/LayoutInlineBoxText.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "LayoutInlineBoxText.h"
-#include "FontFaceHandle.h"
-#include "LayoutEngine.h"
-#include "LayoutLineBox.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/LayoutInlineBoxText.h>
+#include <Rocket/Core/FontFaceHandle.h>
+#include <Rocket/Core/LayoutEngine.h>
+#include <Rocket/Core/LayoutLineBox.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/Log.h>

--- a/Source/Core/LayoutInlineBoxText.h
+++ b/Source/Core/LayoutInlineBoxText.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORELAYOUTINLINEBOXTEXT_H
 #define ROCKETCORELAYOUTINLINEBOXTEXT_H
 
-#include "LayoutInlineBox.h"
+#include <Rocket/Core/LayoutInlineBox.h>
 #include <Rocket/Core/String.h>
 
 namespace Rocket {

--- a/Source/Core/LayoutLineBox.cpp
+++ b/Source/Core/LayoutLineBox.cpp
@@ -25,12 +25,12 @@
  *
  */
 
-#include "precompiled.h"
-#include "LayoutLineBox.h"
-#include "LayoutBlockBox.h"
-#include "LayoutEngine.h"
-#include "LayoutInlineBoxText.h"
-#include "FontFaceHandle.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/LayoutLineBox.h>
+#include <Rocket/Core/LayoutBlockBox.h>
+#include <Rocket/Core/LayoutEngine.h>
+#include <Rocket/Core/LayoutInlineBoxText.h>
+#include <Rocket/Core/FontFaceHandle.h>
 #include <Rocket/Core/Property.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/ElementText.h>

--- a/Source/Core/LayoutLineBox.h
+++ b/Source/Core/LayoutLineBox.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORELAYOUTLINEBOX_H
 #define ROCKETCORELAYOUTLINEBOX_H
 
-#include "LayoutInlineBox.h"
+#include <Rocket/Core/LayoutInlineBox.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Log.cpp
+++ b/Source/Core/Log.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core.h>
 #ifdef ROCKET_PLATFORM_WIN32

--- a/Source/Core/Math.cpp
+++ b/Source/Core/Math.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Math.h>
 #include <time.h>
 #include <math.h>

--- a/Source/Core/Plugin.cpp
+++ b/Source/Core/Plugin.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Plugin.h>
 
 namespace Rocket {

--- a/Source/Core/PluginRegistry.cpp
+++ b/Source/Core/PluginRegistry.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "PluginRegistry.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/PluginRegistry.h>
 #include <Rocket/Core/Plugin.h>
 
 namespace Rocket {

--- a/Source/Core/Property.cpp
+++ b/Source/Core/Property.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Property.h>
 #include <Rocket/Core/PropertyDefinition.h>
 

--- a/Source/Core/PropertyDefinition.cpp
+++ b/Source/Core/PropertyDefinition.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/PropertyDefinition.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/StyleSheetSpecification.h>

--- a/Source/Core/PropertyDictionary.cpp
+++ b/Source/Core/PropertyDictionary.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/PropertyDictionary.h>
 
 namespace Rocket {

--- a/Source/Core/PropertyParserColour.cpp
+++ b/Source/Core/PropertyParserColour.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "PropertyParserColour.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/PropertyParserColour.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/PropertyParserKeyword.cpp
+++ b/Source/Core/PropertyParserKeyword.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "PropertyParserKeyword.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/PropertyParserKeyword.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/PropertyParserNumber.cpp
+++ b/Source/Core/PropertyParserNumber.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "PropertyParserNumber.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/PropertyParserNumber.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/PropertyParserString.cpp
+++ b/Source/Core/PropertyParserString.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "PropertyParserString.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/PropertyParserString.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/PropertySpecification.cpp
+++ b/Source/Core/PropertySpecification.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/PropertySpecification.h>
-#include "PropertyShorthandDefinition.h"
+#include <Rocket/Core/PropertyShorthandDefinition.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/PropertyDefinition.h>
 #include <Rocket/Core/PropertyDictionary.h>

--- a/Source/Core/Python/ContextDocumentProxy.cpp
+++ b/Source/Core/Python/ContextDocumentProxy.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ContextDocumentProxy.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ContextDocumentProxy.h>
 #include <Rocket/Core/Python/NameIndexInterface.h>
 #include <Rocket/Core/Python/Utilities.h>
 #include <Rocket/Core/Context.h>

--- a/Source/Core/Python/ContextInstancer.cpp
+++ b/Source/Core/Python/ContextInstancer.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ContextInstancer.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ContextInstancer.h>
 #include <Rocket/Core/Python/Utilities.h>
 
 namespace Rocket {

--- a/Source/Core/Python/ContextInterface.cpp
+++ b/Source/Core/Python/ContextInterface.cpp
@@ -25,16 +25,16 @@
  *
  */
 
-#include "precompiled.h"
-#include "ContextInterface.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ContextInterface.h>
 
 #include <Rocket/Core/Python/Utilities.h>
 #include <Rocket/Core/Python/Wrapper.h>
 #include <Rocket/Core/Context.h>
 #include <Rocket/Core/Factory.h>
 
-#include "EventListener.h"
-#include "ContextInstancer.h"
+#include <Rocket/Core/Python/EventListener.h>
+#include <Rocket/Core/Python/ContextInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/ContextInterface.h
+++ b/Source/Core/Python/ContextInterface.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREPYTHONCONTEXTINTERFACE_H
 #define ROCKETCOREPYTHONCONTEXTINTERFACE_H
 
-#include "ContextDocumentProxy.h"
+#include <Rocket/Core/Python/ContextDocumentProxy.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/ContextProxy.cpp
+++ b/Source/Core/Python/ContextProxy.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ContextProxy.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ContextProxy.h>
 #include <Rocket/Core/Python/NameIndexInterface.h>
 #include <Rocket/Core/Python/Utilities.h>
 #include <Rocket/Core.h>

--- a/Source/Core/Python/Converters.cpp
+++ b/Source/Core/Python/Converters.cpp
@@ -25,14 +25,14 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/Python/precompiled.h>
 
 #include <Rocket/Core/Variant.h>
 #include <Rocket/Core/Dictionary.h>
 #include <Rocket/Core/Python/ConverterScriptObject.h>
 #include <Rocket/Core/ElementDocument.h>
 
-#include "EventListener.h"
+#include <Rocket/Core/Python/EventListener.h>
 
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 

--- a/Source/Core/Python/DataSourceWrapper.cpp
+++ b/Source/Core/Python/DataSourceWrapper.cpp
@@ -25,12 +25,12 @@
  *
  */
 
-#include "precompiled.h"
-#include "DataSourceWrapper.h"
-#include <EMP/Core/Python/Python.h>
-#include <EMP/Core/Python/Utilities.h>
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/DataSourceWrapper.h>
+#include <Rocket/Core/Python/Python.h>
+#include <Rocket/Controls/Python/DataSourceWrapper.h>
 
-namespace EMP {
+namespace Rocket {
 namespace Core {
 namespace Python {
 
@@ -66,8 +66,8 @@ void DataSourceWrapper::GetRow(StringList& row, const String& table, int row_ind
 	PyObject* callable = PyObject_GetAttrString(self, "GetRow");
 	if (!callable)
 	{
-		Core::String error_message(128, "Function \"GetRow\" not found on python data source %s.", Utilities::GetPythonClassName(self).CString());
-		Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
+		Core::String error_message(128, "Function \"GetRow\" not found on python data source %s.", Rocket::Controls::Python::GetPythonClassName(self).CString());
+		//Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
 		PyErr_SetString(PyExc_RuntimeError, error_message.CString());
 		python::throw_error_already_set();
 		return;
@@ -102,8 +102,8 @@ void DataSourceWrapper::GetRow(StringList& row, const String& table, int row_ind
 			}
 			else
 			{
-				Core::String error_message(128, "Failed to convert row %d entry %d on data source %s.", row_index, i, Utilities::GetPythonClassName(self).CString());
-				Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
+				Core::String error_message(128, "Failed to convert row %d entry %d on data source %s.", row_index, i, Rocket::Controls::Python::GetPythonClassName(self).CString());
+				//Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
 				PyErr_SetString(PyExc_RuntimeError, error_message.CString());
 				python::throw_error_already_set();
 			}
@@ -120,8 +120,8 @@ void DataSourceWrapper::GetRow(StringList& row, const String& table, int row_ind
 		Py_XINCREF(value);
 		Py_XINCREF(traceback);
 
-		Core::String error_message(128, "Failed to get entries for table %s row %d from python data source %s.", table.CString(), row_index, Utilities::GetPythonClassName(self).CString());
-		Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
+		Core::String error_message(128, "Failed to get entries for table %s row %d from python data source %s.", table.CString(), row_index, Rocket::Controls::Python::GetPythonClassName(self).CString());
+		//Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
 		if (type == NULL)
 			PyErr_SetString(PyExc_RuntimeError, error_message.CString());
 		else
@@ -141,8 +141,8 @@ int DataSourceWrapper::GetNumRows(const String& table)
 	PyObject* callable = PyObject_GetAttrString(self, "GetNumRows");
 	if (!callable)
 	{
-		Core::String error_message(128, "Function \"GetNumRows\" not found on python data source %s.", Utilities::GetPythonClassName(self).CString());
-		Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
+		Core::String error_message(128, "Function \"GetNumRows\" not found on python data source %s.", Rocket::Controls::Python::GetPythonClassName(self).CString());
+		//Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
 		PyErr_SetString(PyExc_RuntimeError, error_message.CString());
 		python::throw_error_already_set();
 
@@ -165,8 +165,8 @@ int DataSourceWrapper::GetNumRows(const String& table)
 		Py_XINCREF(value);
 		Py_XINCREF(traceback);
 
-		Core::String error_message(128, "Failed to get number of rows from python data source %s.", Utilities::GetPythonClassName(self).CString());
-		Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
+		Core::String error_message(128, "Failed to get number of rows from python data source %s.", Rocket::Controls::Python::GetPythonClassName(self).CString());
+		//Log::Message(LC_COREPYTHON, Log::LT_WARNING, "%s", error_message.CString());
 		if (type == NULL)
 			PyErr_SetString(PyExc_RuntimeError, error_message.CString());
 		else
@@ -189,3 +189,4 @@ ScriptObject DataSourceWrapper::GetScriptObject() const
 }
 }
 }
+

--- a/Source/Core/Python/DataSourceWrapper.h
+++ b/Source/Core/Python/DataSourceWrapper.h
@@ -28,11 +28,11 @@
 #ifndef EMPCOREPYTHONDATASOURCEWRAPPER_H
 #define EMPCOREPYTHONDATASOURCEWRAPPER_H
 
-#include <EMP/Core/Python/Python.h>
-#include <EMP/Core/Types.h>
-#include <EMP/Core/DataSource.h>
+#include <Rocket/Core/Python/Python.h>
+#include <Rocket/Core/Types.h>
+#include <Rocket/Controls/DataSource.h>
 
-namespace EMP {
+namespace Rocket {
 namespace Core {
 namespace Python {
 
@@ -44,7 +44,7 @@ namespace Python {
 	@author Lloyd Weehuizen
  */
 
-class DataSourceWrapper : public DataSource
+class DataSourceWrapper : public Rocket::Controls::DataSource
 {
 	public:
 		DataSourceWrapper(PyObject* self, const char* name);

--- a/Source/Core/Python/ElementAttributeProxy.cpp
+++ b/Source/Core/Python/ElementAttributeProxy.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementAttributeProxy.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ElementAttributeProxy.h>
 #include <Rocket/Core/Property.h>
 #include <Rocket/Core/Element.h>
 

--- a/Source/Core/Python/ElementChildrenProxy.cpp
+++ b/Source/Core/Python/ElementChildrenProxy.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementChildrenProxy.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ElementChildrenProxy.h>
 #include <Rocket/Core/Property.h>
 #include <Rocket/Core/Element.h>
 

--- a/Source/Core/Python/ElementDocumentWrapper.cpp
+++ b/Source/Core/Python/ElementDocumentWrapper.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementDocumentWrapper.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ElementDocumentWrapper.h>
 #include <Rocket/Core/Stream.h>
 #include <Rocket/Core/Python/Utilities.h>
 

--- a/Source/Core/Python/ElementInterface.cpp
+++ b/Source/Core/Python/ElementInterface.cpp
@@ -25,19 +25,19 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementInterface.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ElementInterface.h>
 #include <Rocket/Core/Python/Utilities.h>
 #include <Rocket/Core/Python/VectorInterface.h>
-#include "../ElementHandle.h"
-#include "../ElementImage.h"
-#include "../ElementTextDefault.h"
+#include <Rocket/Core/Python/../ElementHandle.h>
+#include <Rocket/Core/Python/../ElementImage.h>
+#include <Rocket/Core/Python/../ElementTextDefault.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/Factory.h>
-#include "ElementAttributeProxy.h"
-#include "ElementChildrenProxy.h"
-#include "ElementDocumentWrapper.h"
-#include "ElementStyleProxy.h"
+#include <Rocket/Core/Python/ElementAttributeProxy.h>
+#include <Rocket/Core/Python/ElementChildrenProxy.h>
+#include <Rocket/Core/Python/ElementDocumentWrapper.h>
+#include <Rocket/Core/Python/ElementStyleProxy.h>
 #include <Rocket/Core/Python/ElementInstancer.h>
 #include <Rocket/Core/Python/ElementWrapper.h>
 

--- a/Source/Core/Python/ElementInterface.h
+++ b/Source/Core/Python/ElementInterface.h
@@ -30,10 +30,10 @@
 
 #include <Rocket/Core/Element.h>
 
-#include "ElementStyleProxy.h"
-#include "ElementChildrenProxy.h"
-#include "ElementAttributeProxy.h"
-#include "EventListener.h"
+#include <Rocket/Core/Python/ElementStyleProxy.h>
+#include <Rocket/Core/Python/ElementChildrenProxy.h>
+#include <Rocket/Core/Python/ElementAttributeProxy.h>
+#include <Rocket/Core/Python/EventListener.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/ElementStyleProxy.cpp
+++ b/Source/Core/Python/ElementStyleProxy.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "ElementStyleProxy.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/ElementStyleProxy.h>
 #include <Rocket/Core/Property.h>
 #include <Rocket/Core/Element.h>
 

--- a/Source/Core/Python/EventInstancer.cpp
+++ b/Source/Core/Python/EventInstancer.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/Python/precompiled.h>
 #include <Rocket/Core/Event.h>
 #include <Rocket/Core/Python/Utilities.h>
-#include "EventWrapper.h"
-#include "EventInstancer.h"
+#include <Rocket/Core/Python/EventWrapper.h>
+#include <Rocket/Core/Python/EventInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/EventInterface.cpp
+++ b/Source/Core/Python/EventInterface.cpp
@@ -25,16 +25,16 @@
  *
  */
 
-#include "precompiled.h"
-#include "EventInstancer.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/EventInstancer.h>
 
 #include <Rocket/Core/Python/ConverterScriptObject.h>
 
 #include <Rocket/Core/Factory.h>
 
-#include "EventWrapper.h"
-#include "EventInterface.h"
-#include "EventListenerInstancer.h"
+#include <Rocket/Core/Python/EventWrapper.h>
+#include <Rocket/Core/Python/EventInterface.h>
+#include <Rocket/Core/Python/EventListenerInstancer.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/EventInterface.h
+++ b/Source/Core/Python/EventInterface.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREPYTHONEVENTINTERFACE_H
 #define ROCKETCOREPYTHONEVENTINTERFACE_H
 
-#include "EventWrapper.h"
+#include <Rocket/Core/Python/EventWrapper.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/EventListener.cpp
+++ b/Source/Core/Python/EventListener.cpp
@@ -25,13 +25,13 @@
  *
  */
 
-#include "precompiled.h"
-#include "EventListener.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/EventListener.h>
 
 #include <Rocket/Core/Python/Utilities.h>
 
-#include "EventWrapper.h"
-#include "ElementDocumentWrapper.h"
+#include <Rocket/Core/Python/EventWrapper.h>
+#include <Rocket/Core/Python/ElementDocumentWrapper.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/EventListenerInstancer.cpp
+++ b/Source/Core/Python/EventListenerInstancer.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "EventListenerInstancer.h"
-#include "EventListener.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/EventListenerInstancer.h>
+#include <Rocket/Core/Python/EventListener.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/EventWrapper.cpp
+++ b/Source/Core/Python/EventWrapper.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "EventWrapper.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/EventWrapper.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Python/Interfaces.cpp
+++ b/Source/Core/Python/Interfaces.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/Python/precompiled.h>
 #include <Rocket/Core/URL.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/Dictionary.h>
-//#include "DataSourceWrapper.h"
+//#include <Rocket/Core/Python/DataSourceWrapper.h>
 #include <Rocket/Core/Python/ConverterScriptObject.h>
 #include <Rocket/Core/Python/PickleTypeConverter.h>
 #include <Rocket/Core/Python/Utilities.h>

--- a/Source/Core/Python/Module.cpp
+++ b/Source/Core/Python/Module.cpp
@@ -25,16 +25,16 @@
  *
  */
 
-#include "precompiled.h"
-#include "Module.h"
+#include <Rocket/Core/Python/precompiled.h>
+#include <Rocket/Core/Python/Module.h>
 #include <Rocket/Core/Python/Utilities.h>
 #include <Rocket/Core/Input.h>
 #include <Rocket/Core/Factory.h>
 #include <Rocket/Core/FontDatabase.h>
-#include "ContextInterface.h"
-#include "ContextProxy.h"
-#include "ElementInterface.h"
-#include "EventInterface.h"
+#include <Rocket/Core/Python/ContextInterface.h>
+#include <Rocket/Core/Python/ContextProxy.h>
+#include <Rocket/Core/Python/ElementInterface.h>
+#include <Rocket/Core/Python/EventInterface.h>
 #include <Rocket/Core/Python/ElementInstancer.h>
 
 namespace Rocket {

--- a/Source/Core/Python/Utilities.cpp
+++ b/Source/Core/Python/Utilities.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/Python/precompiled.h>
 #include <Rocket/Core/Python/Utilities.h>
 
 namespace Rocket {

--- a/Source/Core/Python/precompiled.cpp
+++ b/Source/Core/Python/precompiled.cpp
@@ -25,4 +25,4 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/Python/precompiled.h>

--- a/Source/Core/ReferenceCountable.cpp
+++ b/Source/Core/ReferenceCountable.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/ReferenceCountable.h>
 
 namespace Rocket {

--- a/Source/Core/RenderInterface.cpp
+++ b/Source/Core/RenderInterface.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/RenderInterface.h>
-#include "TextureDatabase.h"
+#include <Rocket/Core/TextureDatabase.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Stream.cpp
+++ b/Source/Core/Stream.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Stream.h>
 #include <algorithm>
 #include <stdio.h>

--- a/Source/Core/StreamFile.cpp
+++ b/Source/Core/StreamFile.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StreamFile.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StreamFile.h>
 #include <Rocket/Core/FileInterface.h>
 #include <Rocket/Core.h>
 

--- a/Source/Core/StreamMemory.cpp
+++ b/Source/Core/StreamMemory.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/StreamMemory.h>
 #include <stdio.h>
 

--- a/Source/Core/String.cpp
+++ b/Source/Core/String.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/String.h>
 #include <Rocket/Core/StringBase.h>
 
@@ -90,7 +90,7 @@ String operator+(const char* cstring, const String& string)
 //#define ENABLE_STRING_TESTS
 #ifdef ENABLE_STRING_TESTS
 #include <string>
-#include "Rocket/Core/SystemInterface.h"
+#include <Rocket/Core/Rocket/Core/SystemInterface.h>
 ROCKETCORE_API void StringTests()
 {
 	SystemInterface* sys = Rocket::Core::GetSystemInterface();

--- a/Source/Core/StringCache.cpp
+++ b/Source/Core/StringCache.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StringUtilities.cpp
+++ b/Source/Core/StringUtilities.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/StringUtilities.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/Source/Core/StyleSheet.cpp
+++ b/Source/Core/StyleSheet.cpp
@@ -25,13 +25,13 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/StyleSheet.h>
 #include <algorithm>
-#include "ElementDefinition.h"
-#include "StyleSheetFactory.h"
-#include "StyleSheetNode.h"
-#include "StyleSheetParser.h"
+#include <Rocket/Core/ElementDefinition.h>
+#include <Rocket/Core/StyleSheetFactory.h>
+#include <Rocket/Core/StyleSheetNode.h>
+#include <Rocket/Core/StyleSheetParser.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/PropertyDefinition.h>
 #include <Rocket/Core/StyleSheetSpecification.h>

--- a/Source/Core/StyleSheetFactory.cpp
+++ b/Source/Core/StyleSheetFactory.cpp
@@ -25,21 +25,21 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetFactory.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetFactory.h>
 #include <Rocket/Core/StyleSheet.h>
-#include "StreamFile.h"
-#include "StyleSheetNodeSelectorNthChild.h"
-#include "StyleSheetNodeSelectorNthLastChild.h"
-#include "StyleSheetNodeSelectorNthOfType.h"
-#include "StyleSheetNodeSelectorNthLastOfType.h"
-#include "StyleSheetNodeSelectorFirstChild.h"
-#include "StyleSheetNodeSelectorLastChild.h"
-#include "StyleSheetNodeSelectorFirstOfType.h"
-#include "StyleSheetNodeSelectorLastOfType.h"
-#include "StyleSheetNodeSelectorOnlyChild.h"
-#include "StyleSheetNodeSelectorOnlyOfType.h"
-#include "StyleSheetNodeSelectorEmpty.h"
+#include <Rocket/Core/StreamFile.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthChild.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthLastChild.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthOfType.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthLastOfType.h>
+#include <Rocket/Core/StyleSheetNodeSelectorFirstChild.h>
+#include <Rocket/Core/StyleSheetNodeSelectorLastChild.h>
+#include <Rocket/Core/StyleSheetNodeSelectorFirstOfType.h>
+#include <Rocket/Core/StyleSheetNodeSelectorLastOfType.h>
+#include <Rocket/Core/StyleSheetNodeSelectorOnlyChild.h>
+#include <Rocket/Core/StyleSheetNodeSelectorOnlyOfType.h>
+#include <Rocket/Core/StyleSheetNodeSelectorEmpty.h>
 #include <Rocket/Core/Log.h>
 
 namespace Rocket {

--- a/Source/Core/StyleSheetNode.cpp
+++ b/Source/Core/StyleSheetNode.cpp
@@ -25,12 +25,12 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNode.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNode.h>
 #include <algorithm>
 #include <Rocket/Core/Element.h>
-#include "StyleSheetFactory.h"
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetFactory.h>
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelector.cpp
+++ b/Source/Core/StyleSheetNodeSelector.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorEmpty.cpp
+++ b/Source/Core/StyleSheetNodeSelectorEmpty.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorEmpty.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorEmpty.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorEmpty.h
+++ b/Source/Core/StyleSheetNodeSelectorEmpty.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTOREMPTY_H
 #define ROCKETCORESTYLESHEETNODESELECTOREMPTY_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorFirstChild.cpp
+++ b/Source/Core/StyleSheetNodeSelectorFirstChild.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorFirstChild.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorFirstChild.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorFirstChild.h
+++ b/Source/Core/StyleSheetNodeSelectorFirstChild.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORFIRSTCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORFIRSTCHILD_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorFirstOfType.cpp
+++ b/Source/Core/StyleSheetNodeSelectorFirstOfType.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorFirstOfType.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorFirstOfType.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorFirstOfType.h
+++ b/Source/Core/StyleSheetNodeSelectorFirstOfType.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORFIRSTOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORFIRSTOFTYPE_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorLastChild.cpp
+++ b/Source/Core/StyleSheetNodeSelectorLastChild.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorLastChild.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorLastChild.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorLastChild.h
+++ b/Source/Core/StyleSheetNodeSelectorLastChild.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORLASTCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORLASTCHILD_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorLastOfType.cpp
+++ b/Source/Core/StyleSheetNodeSelectorLastOfType.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorLastOfType.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorLastOfType.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorLastOfType.h
+++ b/Source/Core/StyleSheetNodeSelectorLastOfType.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORLASTOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORLASTOFTYPE_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorNthChild.cpp
+++ b/Source/Core/StyleSheetNodeSelectorNthChild.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorNthChild.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthChild.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/StyleSheetKeywords.h>

--- a/Source/Core/StyleSheetNodeSelectorNthChild.h
+++ b/Source/Core/StyleSheetNodeSelectorNthChild.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHCHILD_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorNthLastChild.cpp
+++ b/Source/Core/StyleSheetNodeSelectorNthLastChild.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorNthLastChild.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthLastChild.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorNthLastChild.h
+++ b/Source/Core/StyleSheetNodeSelectorNthLastChild.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHLASTCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHLASTCHILD_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorNthLastOfType.cpp
+++ b/Source/Core/StyleSheetNodeSelectorNthLastOfType.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorNthLastOfType.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthLastOfType.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorNthLastOfType.h
+++ b/Source/Core/StyleSheetNodeSelectorNthLastOfType.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHLASTOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHLASTOFTYPE_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorNthOfType.cpp
+++ b/Source/Core/StyleSheetNodeSelectorNthOfType.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorNthOfType.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorNthOfType.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorNthOfType.h
+++ b/Source/Core/StyleSheetNodeSelectorNthOfType.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHOFTYPE_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorOnlyChild.cpp
+++ b/Source/Core/StyleSheetNodeSelectorOnlyChild.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorOnlyChild.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorOnlyChild.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorOnlyChild.h
+++ b/Source/Core/StyleSheetNodeSelectorOnlyChild.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORONLYCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORONLYCHILD_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetNodeSelectorOnlyOfType.cpp
+++ b/Source/Core/StyleSheetNodeSelectorOnlyOfType.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetNodeSelectorOnlyOfType.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetNodeSelectorOnlyOfType.h>
 #include <Rocket/Core/ElementText.h>
 #include <Rocket/Core/StyleSheetKeywords.h>
 

--- a/Source/Core/StyleSheetNodeSelectorOnlyOfType.h
+++ b/Source/Core/StyleSheetNodeSelectorOnlyOfType.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCORESTYLESHEETNODESELECTORONLYOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORONLYOFTYPE_H
 
-#include "StyleSheetNodeSelector.h"
+#include <Rocket/Core/StyleSheetNodeSelector.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "StyleSheetParser.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/StyleSheetParser.h>
 #include <algorithm>
-#include "StyleSheetFactory.h"
-#include "StyleSheetNode.h"
+#include <Rocket/Core/StyleSheetFactory.h>
+#include <Rocket/Core/StyleSheetNode.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/StreamMemory.h>
 #include <Rocket/Core/StyleSheet.h>

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -25,12 +25,12 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/StyleSheetSpecification.h>
-#include "PropertyParserNumber.h"
-#include "PropertyParserColour.h"
-#include "PropertyParserKeyword.h"
-#include "PropertyParserString.h"
+#include <Rocket/Core/PropertyParserNumber.h>
+#include <Rocket/Core/PropertyParserColour.h>
+#include <Rocket/Core/PropertyParserKeyword.h>
+#include <Rocket/Core/PropertyParserString.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/SystemInterface.cpp
+++ b/Source/Core/SystemInterface.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/SystemInterface.h>
 #include <Rocket/Core/Log.h>
 

--- a/Source/Core/Template.cpp
+++ b/Source/Core/Template.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "Template.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/Template.h>
+#include <Rocket/Core/XMLParseTools.h>
 #include <Rocket/Core/ElementUtilities.h>
 #include <Rocket/Core/XMLParser.h>
 

--- a/Source/Core/Template.h
+++ b/Source/Core/Template.h
@@ -29,7 +29,7 @@
 #define ROCKETCORETEMPLATE_H
 
 #include <Rocket/Core/StreamMemory.h>
-#include "DocumentHeader.h"
+#include <Rocket/Core/DocumentHeader.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TemplateCache.cpp
+++ b/Source/Core/TemplateCache.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
-#include "TemplateCache.h"
-#include "StreamFile.h"
-#include "Template.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/TemplateCache.h>
+#include <Rocket/Core/StreamFile.h>
+#include <Rocket/Core/Template.h>
 #include <Rocket/Core/Log.h>
 
 namespace Rocket {

--- a/Source/Core/Texture.cpp
+++ b/Source/Core/Texture.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Texture.h>
-#include "TextureDatabase.h"
-#include "TextureResource.h"
+#include <Rocket/Core/TextureDatabase.h>
+#include <Rocket/Core/TextureResource.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureDatabase.cpp
+++ b/Source/Core/TextureDatabase.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "TextureDatabase.h"
-#include "TextureResource.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/TextureDatabase.h>
+#include <Rocket/Core/TextureResource.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/TextureLayout.cpp
+++ b/Source/Core/TextureLayout.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "TextureLayout.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/TextureLayout.h>
 #include <algorithm>
-#include "TextureLayoutRectangle.h"
-#include "TextureLayoutTexture.h"
+#include <Rocket/Core/TextureLayoutRectangle.h>
+#include <Rocket/Core/TextureLayoutTexture.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureLayout.h
+++ b/Source/Core/TextureLayout.h
@@ -28,8 +28,8 @@
 #ifndef TEXTURELAYOUT_H
 #define TEXTURELAYOUT_H
 
-#include "TextureLayoutRectangle.h"
-#include "TextureLayoutTexture.h"
+#include <Rocket/Core/TextureLayoutRectangle.h>
+#include <Rocket/Core/TextureLayoutTexture.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureLayoutRectangle.cpp
+++ b/Source/Core/TextureLayoutRectangle.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "TextureLayoutRectangle.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/TextureLayoutRectangle.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureLayoutRow.cpp
+++ b/Source/Core/TextureLayoutRow.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "TextureLayoutRow.h"
-#include "TextureLayout.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/TextureLayoutRow.h>
+#include <Rocket/Core/TextureLayout.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureLayoutRow.h
+++ b/Source/Core/TextureLayoutRow.h
@@ -28,7 +28,7 @@
 #ifndef TEXTURELAYOUTROW_H
 #define TEXTURELAYOUTROW_H
 
-#include "TextureLayoutRectangle.h"
+#include <Rocket/Core/TextureLayoutRectangle.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureLayoutTexture.cpp
+++ b/Source/Core/TextureLayoutTexture.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "TextureLayoutTexture.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/TextureLayoutTexture.h>
 #include <Rocket/Core/Core.h>
-#include "TextureDatabase.h"
-#include "TextureLayout.h"
+#include <Rocket/Core/TextureDatabase.h>
+#include <Rocket/Core/TextureLayout.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureLayoutTexture.h
+++ b/Source/Core/TextureLayoutTexture.h
@@ -29,7 +29,7 @@
 #define TEXTURELAYOUTTEXTURE_H
 
 #include <Rocket/Core/Texture.h>
-#include "TextureLayoutRow.h"
+#include <Rocket/Core/TextureLayoutRow.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/TextureResource.cpp
+++ b/Source/Core/TextureResource.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
-#include "TextureResource.h"
-#include "FontFaceHandle.h"
-#include "TextureDatabase.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/TextureResource.h>
+#include <Rocket/Core/FontFaceHandle.h>
+#include <Rocket/Core/TextureDatabase.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/URL.cpp
+++ b/Source/Core/URL.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/URL.h>
 #include <stdio.h>
 

--- a/Source/Core/UnicodeRange.cpp
+++ b/Source/Core/UnicodeRange.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "UnicodeRange.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/UnicodeRange.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/Variant.cpp
+++ b/Source/Core/Variant.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Variant.h>
 
 namespace Rocket {

--- a/Source/Core/Vector2.cpp
+++ b/Source/Core/Vector2.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/Types.h>
 
 namespace Rocket {

--- a/Source/Core/WString.cpp
+++ b/Source/Core/WString.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/WString.h>
 
 namespace Rocket {

--- a/Source/Core/WidgetSlider.cpp
+++ b/Source/Core/WidgetSlider.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
-#include "WidgetSlider.h"
-#include "Clock.h"
-#include "LayoutEngine.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/WidgetSlider.h>
+#include <Rocket/Core/Clock.h>
+#include <Rocket/Core/LayoutEngine.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Event.h>
 #include <Rocket/Core/Factory.h>

--- a/Source/Core/WidgetSliderScroll.cpp
+++ b/Source/Core/WidgetSliderScroll.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "precompiled.h"
-#include "WidgetSliderScroll.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/WidgetSliderScroll.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/WidgetSliderScroll.h
+++ b/Source/Core/WidgetSliderScroll.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREWIDGETSLIDERSCROLL_H
 #define ROCKETCOREWIDGETSLIDERSCROLL_H
 
-#include "WidgetSlider.h"
+#include <Rocket/Core/WidgetSlider.h>
 
 namespace Rocket {
 namespace Core {

--- a/Source/Core/XMLNodeHandler.cpp
+++ b/Source/Core/XMLNodeHandler.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/XMLNodeHandler.h>
 
 namespace Rocket {

--- a/Source/Core/XMLNodeHandlerBody.cpp
+++ b/Source/Core/XMLNodeHandlerBody.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "XMLNodeHandlerBody.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/XMLNodeHandlerBody.h>
+#include <Rocket/Core/XMLParseTools.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/XMLNodeHandlerDefault.cpp
+++ b/Source/Core/XMLNodeHandlerDefault.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
-#include "XMLNodeHandlerDefault.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/XMLNodeHandlerDefault.h>
+#include <Rocket/Core/XMLParseTools.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Factory.h>

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -25,10 +25,10 @@
  *
  */
 
-#include "precompiled.h"
-#include "XMLNodeHandlerHead.h"
-#include "DocumentHeader.h"
-#include "TemplateCache.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/XMLNodeHandlerHead.h>
+#include <Rocket/Core/DocumentHeader.h>
+#include <Rocket/Core/TemplateCache.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/XMLNodeHandlerTemplate.cpp
+++ b/Source/Core/XMLNodeHandlerTemplate.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "XMLNodeHandlerTemplate.h"
-#include "Template.h"
-#include "TemplateCache.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/XMLNodeHandlerTemplate.h>
+#include <Rocket/Core/Template.h>
+#include <Rocket/Core/TemplateCache.h>
+#include <Rocket/Core/XMLParseTools.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Core/XMLParseTools.cpp
+++ b/Source/Core/XMLParseTools.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "precompiled.h"
-#include "XMLParseTools.h"
+#include <Rocket/Core/precompiled.h>
+#include <Rocket/Core/XMLParseTools.h>
 #include <Rocket/Core/StreamMemory.h>
-#include "Template.h"
-#include "TemplateCache.h"
+#include <Rocket/Core/Template.h>
+#include <Rocket/Core/TemplateCache.h>
 #include <Rocket/Core.h>
 #include <ctype.h>
 

--- a/Source/Core/XMLParser.cpp
+++ b/Source/Core/XMLParser.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 #include <Rocket/Core/XMLParser.h>
-#include "DocumentHeader.h"
+#include <Rocket/Core/DocumentHeader.h>
 #include <Rocket/Core/Log.h>
 #include <Rocket/Core/XMLNodeHandler.h>
 

--- a/Source/Core/precompiled.cpp
+++ b/Source/Core/precompiled.cpp
@@ -25,5 +25,5 @@
  *
  */
 
-#include "precompiled.h"
+#include <Rocket/Core/precompiled.h>
 

--- a/Source/Core/precompiled.h
+++ b/Source/Core/precompiled.h
@@ -29,6 +29,6 @@
 #define ROCKETCOREPRECOMPILED_H
 
 #include <Rocket/Core/Core.h>
-#include "StringCache.h"
+#include <Rocket/Core/StringCache.h>
 
 #endif

--- a/Source/Debugger/Debugger.cpp
+++ b/Source/Debugger/Debugger.cpp
@@ -27,7 +27,7 @@
 
 #include <Rocket/Debugger/Debugger.h>
 #include <Rocket/Core.h>
-#include "Plugin.h"
+#include <Rocket/Debugger/Plugin.h>
 
 namespace Rocket {
 namespace Debugger {

--- a/Source/Debugger/ElementContextHook.cpp
+++ b/Source/Debugger/ElementContextHook.cpp
@@ -25,8 +25,8 @@
  *
  */
 
-#include "ElementContextHook.h"
-#include "Plugin.h"
+#include <Rocket/Debugger/ElementContextHook.h>
+#include <Rocket/Debugger/Plugin.h>
 
 namespace Rocket {
 namespace Debugger {

--- a/Source/Debugger/ElementInfo.cpp
+++ b/Source/Debugger/ElementInfo.cpp
@@ -25,13 +25,13 @@
  *
  */
 
-#include "ElementInfo.h"
+#include <Rocket/Debugger/ElementInfo.h>
 #include <Rocket/Core/Property.h>
 #include <Rocket/Core/Factory.h>
 #include <Rocket/Core/StyleSheet.h>
-#include "Geometry.h"
-#include "CommonSource.h"
-#include "InfoSource.h"
+#include <Rocket/Debugger/Geometry.h>
+#include <Rocket/Debugger/CommonSource.h>
+#include <Rocket/Debugger/InfoSource.h>
 #include <map>
 
 namespace Rocket {

--- a/Source/Debugger/ElementLog.cpp
+++ b/Source/Debugger/ElementLog.cpp
@@ -25,11 +25,11 @@
  *
  */
 
-#include "ElementLog.h"
+#include <Rocket/Debugger/ElementLog.h>
 #include <Rocket/Core.h>
-#include "CommonSource.h"
-#include "BeaconSource.h"
-#include "LogSource.h"
+#include <Rocket/Debugger/CommonSource.h>
+#include <Rocket/Debugger/BeaconSource.h>
+#include <Rocket/Debugger/LogSource.h>
 
 namespace Rocket {
 namespace Debugger {

--- a/Source/Debugger/Geometry.cpp
+++ b/Source/Debugger/Geometry.cpp
@@ -25,7 +25,7 @@
  *
  */
 
-#include "Geometry.h"
+#include <Rocket/Debugger/Geometry.h>
 #include <Rocket/Core.h>
 
 namespace Rocket {

--- a/Source/Debugger/Plugin.cpp
+++ b/Source/Debugger/Plugin.cpp
@@ -25,16 +25,16 @@
  *
  */
 
-#include "Plugin.h"
+#include <Rocket/Debugger/Plugin.h>
 #include <Rocket/Core/Types.h>
 #include <Rocket/Core.h>
-#include "ElementContextHook.h"
-#include "ElementInfo.h"
-#include "ElementLog.h"
-#include "FontSource.h"
-#include "Geometry.h"
-#include "MenuSource.h"
-#include "SystemInterface.h"
+#include <Rocket/Debugger/ElementContextHook.h>
+#include <Rocket/Debugger/ElementInfo.h>
+#include <Rocket/Debugger/ElementLog.h>
+#include <Rocket/Debugger/FontSource.h>
+#include <Rocket/Debugger/Geometry.h>
+#include <Rocket/Debugger/MenuSource.h>
+#include <Rocket/Debugger/SystemInterface.h>
 #include <stack>
 
 namespace Rocket {

--- a/Source/Debugger/SystemInterface.cpp
+++ b/Source/Debugger/SystemInterface.cpp
@@ -25,9 +25,9 @@
  *
  */
 
-#include "SystemInterface.h"
+#include <Rocket/Debugger/SystemInterface.h>
 #include <Rocket/Core.h>
-#include "ElementLog.h"
+#include <Rocket/Debugger/ElementLog.h>
 
 namespace Rocket {
 namespace Debugger {

--- a/readme.md
+++ b/readme.md
@@ -44,3 +44,11 @@ this, you don't have to learn a whole new proprietary technology like other libr
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
+
+
+
+# Ignifuga
+
+This is version is slightly modified from the official repository 
+to better suit Ignifuga's way of compiling modules into Python which
+requires a flat file structure


### PR DESCRIPTION
This pull requests "fixes" the include paths used on libRocket so all paths are "absolute" from the Rocket root. I needed this because the build system in my engine flattens the source code into a single folder and the compiler was having trouble finding the headers. It's a trivial but extensive change, I leave it up to you if you think it's worth incorporating.
I mistakenly added the readme.md change I made to mark my repo as having changes for my engine, so you may want to remove that :)
