### PR TITLE
Fix for Clipboard Paste Bug

### DIFF
--- a/Source/Controls/Clipboard.cpp
+++ b/Source/Controls/Clipboard.cpp
@@ -76,13 +76,17 @@ Core::WString Clipboard::Get()
 
 		HANDLE clipboard_data = GetClipboardData(CF_UNICODETEXT);
 		if (clipboard_data == NULL)
+		{
+			CloseClipboard();
 			return clipboard_content;
+		}
 
 		const Rocket::Core::word* clipboard_text = (const Rocket::Core::word*) GlobalLock(clipboard_data);
 		if (clipboard_text)
 			clipboard_content.Assign(clipboard_text);
 		GlobalUnlock(clipboard_data);
 
+		CloseClipboard();
 		return clipboard_content;
 	}
 	else


### PR DESCRIPTION
libRocket does not properly release the clipboard after the user performs a paste action, causing the system clipboard to no longer function. 

This fix allows libRocket to properly release the system clipboard so the clipboard functions as users would expect.
