### PR TITLE
Bugfix: fixed error building libRocket with MinGW

### DIFF
--- a/Include/Rocket/Core/Platform.h
+++ b/Include/Rocket/Core/Platform.h
@@ -28,7 +28,7 @@
 #ifndef ROCKETCOREPLATFORM_H
 #define ROCKETCOREPLATFORM_H
 
-#if defined __WIN32__ || defined _WIN32
+#if (defined __WIN32__ || defined _WIN32) && !defined __MINGW32__
 	#define ROCKET_PLATFORM_WIN32
 	#define ROCKET_PLATFORM_NAME "win32"
 	#if !defined(__MINGW32__)


### PR DESCRIPTION
When librocket was build with MinGW the wrong platform was selected. As
a consequence the wrong code was compiled which lead to corrupted
libraries.
