### PR TITLE
Add cursor-class property to stylesheet

### DIFF
--- a/Include/Rocket/Core/Context.h
+++ b/Include/Rocket/Core/Context.h
@@ -120,10 +120,17 @@ public:
 	void UnloadMouseCursor(const String& cursor_name);
 	/// Unloads all currently loaded cursors.
 	void UnloadAllMouseCursors();
+	/// Gets the active cursor.
+	/// @return The active cursor document.
+	ElementDocument* GetActiveCursor();
 	/// Sets a cursor as the active cursor.
 	/// @param[in] cursor_name The name of the cursor to activate.
 	/// @return True if a cursor exists with the given name, false if not.
 	bool SetMouseCursor(const String& cursor_name);
+	/// Sets a cursor class for the active cursor.
+	/// @param[in] class_name The name of the class for the active cursor.
+	/// @return True if an active cursor exists, false if not.
+	bool SetMouseCursorClass(const String& class_name);
 	/// Shows or hides the cursor.
 	/// @param[in] show True to show the cursor, false to hide it.
 	void ShowMouseCursor(bool show);

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -400,7 +400,12 @@ void Context::UnloadMouseCursor(const String& cursor_name)
 void Context::UnloadAllMouseCursors()
 {
 	while (!cursors.empty())
-		UnloadMouseCursor((*cursors.begin()).first.CString());
+        UnloadMouseCursor((*cursors.begin()).first.CString());
+}
+
+ElementDocument *Context::GetActiveCursor()
+{
+    return static_cast<ElementDocument*>(*active_cursor);
 }
 
 // Sets a cursor as the active cursor.
@@ -415,7 +420,19 @@ bool Context::SetMouseCursor(const String& cursor_name)
 	}
 
 	active_cursor = (*i).second;
-	return true;
+    return true;
+}
+
+bool Context::SetMouseCursorClass(const String &class_name)
+{
+    ElementDocument* cursor = GetActiveCursor();
+
+    if (cursor != NULL)
+    {
+        cursor->SetClassNames(class_name);
+    }
+
+    return false;
 }
 
 // Shows or hides the cursor.
@@ -975,10 +992,16 @@ void Context::UpdateHoverChain(const Dictionary& parameters, const Dictionary& d
 	hover = GetElementAtPoint(position);
 
 	if (!hover ||
-		hover->GetProperty(CURSOR)->unit == Property::KEYWORD)
+        hover->GetProperty(CURSOR)->unit == Property::KEYWORD)
 		active_cursor = default_cursor;
 	else
 		SetMouseCursor(hover->GetProperty< String >(CURSOR));
+
+	if (!hover || hover->GetProperty(CURSOR_CLASS)->unit == Property::KEYWORD)
+        SetMouseCursorClass("");
+    else
+        SetMouseCursorClass(hover->GetProperty< String >(CURSOR_CLASS));
+
 
 	// Build the new hover chain.
 	ElementSet new_hover_chain;

--- a/Source/Core/StringCache.cpp
+++ b/Source/Core/StringCache.cpp
@@ -89,6 +89,7 @@ const String TEXT_DECORATION = "text-decoration";
 const String TEXT_TRANSFORM = "text-transform";
 const String WHITE_SPACE = "white-space";
 const String CURSOR = "cursor";
+const String CURSOR_CLASS = "cursor-class";
 const String DRAG = "drag";
 const String TAB_INDEX = "tab-index";
 const String SCROLLBAR_MARGIN = "scrollbar-margin";

--- a/Source/Core/StringCache.h
+++ b/Source/Core/StringCache.h
@@ -92,6 +92,7 @@ extern const String TEXT_DECORATION;
 extern const String TEXT_TRANSFORM;
 extern const String WHITE_SPACE;
 extern const String CURSOR;
+extern const String CURSOR_CLASS;
 extern const String DRAG;
 extern const String TAB_INDEX;
 extern const String SCROLLBAR_MARGIN;

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -251,9 +251,12 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(TEXT_TRANSFORM, "none", true, true).AddParser("keyword", "none, capitalize, uppercase, lowercase");
 	RegisterProperty(WHITE_SPACE, "normal", true, true).AddParser("keyword", "normal, pre, nowrap, pre-wrap, pre-line");
 
-	RegisterProperty(CURSOR, "auto", true, false)
-		.AddParser("keyword", "auto")
-		.AddParser("string");
+    RegisterProperty(CURSOR, "auto", true, false)
+        .AddParser("keyword", "auto")
+        .AddParser("string");
+    RegisterProperty(CURSOR_CLASS, "auto", true, false)
+        .AddParser("keyword", "auto")
+        .AddParser("string");
 
 	// Functional property specifications.
 	RegisterProperty(DRAG, "none", false, false).AddParser("keyword", "none, drag, drag-drop, block, clone");


### PR DESCRIPTION
This prevents you from having to create a new RML file for each cursor, given most will look identical with different decorators and offset.

This will simply set the specified class on the body element of the cursor document.
This class can then be targeted from within the document's styles to apply different decorators etc.

An example:

``` html
<rml>
<head>
<title>cursor</title>
<style>
body
{
width: 15px;
height: 20px;
}

body .cursor
{
position: relative;
width: 15px;
height: 20px;
left: -5px;

cursor-decorator: image;
cursor-image: canvas.png 10px 16px 25px 32px;
}

body.pointer .cursor
{
cursor-decorator: image;
cursor-image: canvas.png 25px 14px 40px 34px;
}
</style>
</head>
<body>
<div class="cursor"></div>
</body>
</rml>
```

Then somewhere in a stylesheet:

``` css
button
{
    cursor: "cursor";
    cursor-class: "pointer";
}
```
