### PR TITLE
Windows x64 compatible ROCKET_BREAK

### DIFF
--- a/Include/Rocket/Core/Debug.h
+++ b/Include/Rocket/Core/Debug.h
@@ -35,7 +35,7 @@
 	#if defined (__MINGW32__)
 		#define ROCKET_BREAK asm("int $0x03")
 	#else
-		#define ROCKET_BREAK _asm { int 0x03 }
+		#define ROCKET_BREAK __debugbreak();
 	#endif
 #elif defined (ROCKET_PLATFORM_LINUX)
 	#if defined __i386__ || defined __x86_64__


### PR DESCRIPTION
On x64 inline asm doesn't compile, so changed to the __debugbreak() intrinsic function to provide a win32/x64 compatible solution.
