### PR TITLE
Fix compilation warnings

### DIFF
--- a/Source/Core/FontDatabase.cpp
+++ b/Source/Core/FontDatabase.cpp
@@ -279,7 +279,7 @@ void* FontDatabase::LoadFace(const String& file_name)
 
 	if (!handle)
 	{
-		return false;
+		return NULL;
 	}
 
 	size_t length = file_interface->Length(handle);

--- a/Source/Core/TextureResource.cpp
+++ b/Source/Core/TextureResource.cpp
@@ -162,7 +162,7 @@ bool TextureResource::Load(RenderInterface* render_interface) const
 			else
 			{
 				Log::Message(Log::LT_WARNING, "Failed to generate internal texture %s.", source.CString());
-				texture_data[render_interface] = TextureData(NULL, Vector2i(0, 0));
+				texture_data[render_interface] = TextureData(0, Vector2i(0, 0));
 
 				return false;
 			}
@@ -174,7 +174,7 @@ bool TextureResource::Load(RenderInterface* render_interface) const
 	if (!render_interface->LoadTexture(handle, dimensions, source))
 	{
 		Log::Message(Log::LT_WARNING, "Failed to load texture from %s.", source.CString());
-		texture_data[render_interface] = TextureData(NULL, Vector2i(0, 0));
+		texture_data[render_interface] = TextureData(0, Vector2i(0, 0));
 
 		return false;
 	}


### PR DESCRIPTION
In member function ‘void\* Rocket::Core::FontDatabase::LoadFace(const String&)’:
Source/Core/FontDatabase.cpp:257:10: warning: converting ‘false’ to pointer type ‘void*’

In member function ‘bool Rocket::Core::TextureResource::Load(Rocket::Core::RenderInterface*) const’:
Source/Core/TextureResource.cpp:165:70: warning: passing NULL to non-pointer argument 1 of ‘std::pair'
Source/Core/TextureResource.cpp:177:68: warning: passing NULL to non-pointer argument 1 of ‘std::pair'
