### PR TITLE
Copy-paste fix for elements with max_length set.

### DIFF
--- a/Source/Controls/WidgetTextInput.cpp
+++ b/Source/Controls/WidgetTextInput.cpp
@@ -351,7 +351,7 @@ void WidgetTextInput::ProcessEvent(Core::Event& event)
     				for (size_t i = 0; i < clipboard_content.Length(); ++i)
     				{
     					if (max_length > 0 &&
-    						(int) Core::WString(GetElement()->GetAttribute< Rocket::Core::String >("value", "")).Length() < max_length)
+    						(int) Core::WString(GetElement()->GetAttribute< Rocket::Core::String >("value", "")).Length() > max_length)
     						break;
 
     					AddCharacter(clipboard_content[i]);


### PR DESCRIPTION
Copy-paste wasn't working with elements which had a max length set, that's fixed with this commit.
