### PR TITLE
Free strings returned by XGetAtomName to avoid leakage.

### DIFF
--- a/Samples/shell/src/x11/ShellX11.cpp
+++ b/Samples/shell/src/x11/ShellX11.cpp
@@ -198,6 +198,7 @@ void Shell::EventLoop(ShellIdleFunction idle_function)
 		while (XPending(display) > 0)
 		{
 			XEvent event;
+			char *event_type = 0;
 			XNextEvent(display, &event);
 
 			switch (event.type)
@@ -206,8 +207,11 @@ void Shell::EventLoop(ShellIdleFunction idle_function)
 				{
 					// The only message we register for is WM_DELETE_WINDOW, so if we receive a client message then the
 					// window has been closed.
-					if (strcmp(XGetAtomName(display, event.xclient.message_type), "WM_PROTOCOLS") == 0)
+					event_type = XGetAtomName(display, event.xclient.message_type);
+					if (strcmp(event_type, "WM_PROTOCOLS") == 0)
 						running = false;
+					XFree(event_type);
+					event_type = 0;
 				}
 				break;
 


### PR DESCRIPTION
Call XFree() on the string returned by XGetAtomName() in the Linux part of the Shell to avoid a memory leak.
