### PR TITLE
Bring back PPI-based units

### DIFF
--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -368,7 +368,7 @@ float ElementStyle::ResolveProperty(const Property* property, float base_value)
 	{
 		float inch = property->value.Get< float >() * element->GetRenderInterface()->GetPixelsPerInch();
 		
-		if (property->unit & Property::IN) // inch
+		if (property->unit & Property::INCH) // inch
 			return inch;
 		if (property->unit & Property::CM) // centimeter
 			return inch * (1.0f / 2.54f);

--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -141,20 +141,33 @@ int ElementUtilities::GetLineHeight(Element* element)
 		return 0;
 
 	int line_height = font_face_handle->GetLineHeight();
+	float inch = element->GetRenderInterface()->GetPixelsPerInch();
 	const Property* line_height_property = element->GetLineHeightProperty();
 
-	// If the property is a straight number or an em measurement, then it scales the line height.
-	if (line_height_property->unit == Property::NUMBER ||
-		line_height_property->unit == Property::EM)
+	switch (line_height_property->unit)
+	{
+	case Property::NUMBER:
+	case Property::EM:
+		// If the property is a straight number or an em measurement, then it scales the line height.
 		return Math::Round(line_height_property->value.Get< float >() * line_height);
-
-	// If the property is a percentage, then it scales the line height.
-	else if (line_height_property->unit == Property::PERCENT)
+	case Property::PERCENT:
+		// If the property is a percentage, then it scales the line height.
 		return Math::Round(line_height_property->value.Get< float >() * line_height * 0.01f);
-
-	// Otherwise, we're a px measurement.
-	else if (line_height_property->unit == Property::PX)
+	case Property::PX:
+		// A px measurement.
 		return Math::Round(line_height_property->value.Get< float >());
+	case Property::INCH:
+		// Values based on pixels-per-inch.
+		return Math::Round(line_height_property->value.Get< float >() * inch);
+	case Property::CM:
+		return Math::Round(line_height_property->value.Get< float >() * inch * (1.0f / 2.54f));
+	case Property::MM:
+		return Math::Round(line_height_property->value.Get< float >() * inch * (1.0f / 25.4f));
+	case Property::PT:
+		return Math::Round(line_height_property->value.Get< float >() * inch * (1.0f / 72.0f));
+	case Property::PC:
+		return Math::Round(line_height_property->value.Get< float >() * inch * (1.0f / 6.0f));
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The main developer of the game engine I'm working on accidentally removed PPI-based RCSS unit support. I need them in the engine now, so I'm adding them back here.
