### PR TITLE
Detect 64bit using proper macros

### DIFF
--- a/Include/Rocket/Core/Platform.h
+++ b/Include/Rocket/Core/Platform.h
@@ -48,7 +48,7 @@
 	#define ROCKET_DEBUG
 #endif
 
-#if defined __x86_64__ || defined _M_X64 || defined __powerpc64__ || defined __alpha__ || defined __ia64__ || defined __s390__ || defined __s390x__
+#if defined __LP64__ || defined _M_X64 || defined __MING64__
     #define ROCKET_ARCH_64
 #else
     #define ROCKET_ARCH_32


### PR DESCRIPTION
Uses the proper GCC/LLVM, MSVC and Ming macros to detect 64 bit across platforms
