### PR TITLE
Fixed compiler warnings due to order of initialization values for base class constructors

### DIFF
--- a/Source/Controls/WidgetTextInput.cpp
+++ b/Source/Controls/WidgetTextInput.cpp
@@ -37,7 +37,7 @@ namespace Controls {
 
 const float CURSOR_BLINK_TIME = 0.7f;
 
-WidgetTextInput::WidgetTextInput(ElementFormControl* _parent) : internal_dimensions(0, 0), scroll_offset(0, 0), cursor_position(0, 0), cursor_size(0, 0), cursor_geometry(_parent), selection_geometry(_parent)
+WidgetTextInput::WidgetTextInput(ElementFormControl* _parent) : internal_dimensions(0, 0), scroll_offset(0, 0), selection_geometry(_parent), cursor_position(0, 0), cursor_size(0, 0), cursor_geometry(_parent)
 {
 	keyboard_showed = false;
 	

--- a/Source/Core/Box.cpp
+++ b/Source/Core/Box.cpp
@@ -32,13 +32,13 @@ namespace Rocket {
 namespace Core {
 
 // Initialises a zero-sized box.
-Box::Box() : offset(0, 0), content(0, 0)
+Box::Box() : content(0, 0), offset(0, 0)
 {
 	memset(area_edges, 0, sizeof(area_edges));
 }
 
 // Initialises a box with a default content area and no padding, borders and margins.
-Box::Box(const Vector2f& content) : offset(0, 0), content(content)
+Box::Box(const Vector2f& content) : content(content), offset(0, 0)
 {
 	memset(area_edges, 0, sizeof(area_edges));
 }

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -40,7 +40,7 @@ namespace Core {
 
 const float DOUBLE_CLICK_TIME = 0.5f;
 
-Context::Context(const String& name) : name(name), mouse_position(0, 0), dimensions(0, 0), clip_origin(-1, -1), clip_dimensions(-1, -1)
+Context::Context(const String& name) : name(name), dimensions(0, 0), mouse_position(0, 0), clip_origin(-1, -1), clip_dimensions(-1, -1)
 {
 	instancer = NULL;
 

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -73,7 +73,7 @@ public:
 };
 
 /// Constructs a new libRocket element.
-Element::Element(const String& _tag) : absolute_offset(0, 0), relative_offset_base(0, 0), relative_offset_position(0, 0), scroll_offset(0, 0), content_offset(0, 0), content_box(0, 0), boxes(1)
+Element::Element(const String& _tag) : relative_offset_base(0, 0), relative_offset_position(0, 0), absolute_offset(0, 0), scroll_offset(0, 0), boxes(1), content_offset(0, 0), content_box(0, 0)
 {
 	tag = _tag.ToLower();
 	parent = NULL;

--- a/Source/Core/Event.cpp
+++ b/Source/Core/Event.cpp
@@ -41,7 +41,7 @@ Event::Event()
 	target_element = NULL;
 }
 
-Event::Event(Element* _target_element, const String& _type, const Dictionary& _parameters, bool _interruptible) : parameters(_parameters), target_element(_target_element), type(_type), interruptible(_interruptible)
+Event::Event(Element* _target_element, const String& _type, const Dictionary& _parameters, bool _interruptible) : type(_type), parameters(_parameters), target_element(_target_element), interruptible(_interruptible)
 {
 	phase = PHASE_UNKNOWN;
 	interruped = false;

--- a/Source/Core/LayoutBlockBoxSpace.cpp
+++ b/Source/Core/LayoutBlockBoxSpace.cpp
@@ -36,7 +36,7 @@
 namespace Rocket {
 namespace Core {
 
-LayoutBlockBoxSpace::LayoutBlockBoxSpace(LayoutBlockBox* _parent) : dimensions(0, 0), offset(0, 0)
+LayoutBlockBoxSpace::LayoutBlockBoxSpace(LayoutBlockBox* _parent) : offset(0, 0), dimensions(0, 0)
 {
 	parent = _parent;
 }

--- a/Source/Core/LayoutInlineBox.cpp
+++ b/Source/Core/LayoutInlineBox.cpp
@@ -39,7 +39,7 @@ namespace Rocket {
 namespace Core {
 
 // Constructs a new inline box for an element.
-LayoutInlineBox::LayoutInlineBox(Element* _element, const Box& _box) : box(_box), position(0, 0)
+LayoutInlineBox::LayoutInlineBox(Element* _element, const Box& _box) : position(0, 0), box(_box)
 {
 	line = NULL;
 
@@ -81,7 +81,7 @@ LayoutInlineBox::LayoutInlineBox(Element* _element, const Box& _box) : box(_box)
 }
 
 // Constructs a new inline box for a split box.
-LayoutInlineBox::LayoutInlineBox(LayoutInlineBox* _chain) : box(_chain->GetBox()), position(0, 0)
+LayoutInlineBox::LayoutInlineBox(LayoutInlineBox* _chain) : position(0, 0), box(_chain->GetBox())
 {
 	line = NULL;
 


### PR DESCRIPTION
Should make no functional change, just squelches warnings
