### PR TITLE
Slight changes for easy of understanding/debugging using unused variables

### DIFF
--- a/Samples/invaders/src/DecoratorDefender.cpp
+++ b/Samples/invaders/src/DecoratorDefender.cpp
@@ -66,7 +66,7 @@ void DecoratorDefender::RenderElement(Rocket::Core::Element* element, Rocket::Co
 	glEnable(GL_TEXTURE_2D);
 	glBindTexture(GL_TEXTURE_2D, (GLuint) GetTexture(image_index)->GetHandle(element->GetRenderInterface()));
 	Rocket::Core::Colourb colour = element->GetProperty< Rocket::Core::Colourb >("color");
-	glColor4ubv(element->GetProperty< Rocket::Core::Colourb >("color"));
+	glColor4ubv(colour);
 	glBegin(GL_QUADS);
 
 		glVertex2f(position.x, position.y);

--- a/Samples/tutorial/datagrid/src/DecoratorDefender.cpp
+++ b/Samples/tutorial/datagrid/src/DecoratorDefender.cpp
@@ -50,7 +50,7 @@ void DecoratorDefender::RenderElement(Rocket::Core::Element* element, Rocket::Co
 	glEnable(GL_TEXTURE_2D);
 	glBindTexture(GL_TEXTURE_2D, (GLuint) GetTexture(image_index)->GetHandle(element->GetRenderInterface()));
 	Rocket::Core::Colourb colour = element->GetProperty< Rocket::Core::Colourb >("color");
-	glColor4ubv(element->GetProperty< Rocket::Core::Colourb >("color"));
+	glColor4ubv(colour);
 	glBegin(GL_QUADS);
 
 		glVertex2f(position.x, position.y);

--- a/Samples/tutorial/datagrid_tree/src/DecoratorDefender.cpp
+++ b/Samples/tutorial/datagrid_tree/src/DecoratorDefender.cpp
@@ -50,7 +50,7 @@ void DecoratorDefender::RenderElement(Rocket::Core::Element* element, Rocket::Co
 	glEnable(GL_TEXTURE_2D);
 	glBindTexture(GL_TEXTURE_2D, (GLuint) GetTexture(image_index)->GetHandle(element->GetRenderInterface()));
 	Rocket::Core::Colourb colour = element->GetProperty< Rocket::Core::Colourb >("color");
-	glColor4ubv(element->GetProperty< Rocket::Core::Colourb >("color"));
+	glColor4ubv(colour);
 	glBegin(GL_QUADS);
 
 		glVertex2f(position.x, position.y);


### PR DESCRIPTION
It looks like during a previous code review/merge some bits of code was changed to inline method calls instead of dumping them to a variable then using that variable.  The result was calling was multiple calls to the same lookup method with one of the results never being used.  I'm reverting to the easier to read variant as its far easier to debug when there is a variable/new line than with inlined calls.  The compiler will optimize the variables away if possible anyway.
