### PR TITLE
Added const qualifier as this method should not modify any member variables

### DIFF
--- a/Include/Rocket/Core/StreamMemory.h
+++ b/Include/Rocket/Core/StreamMemory.h
@@ -74,7 +74,7 @@ public:
 	virtual size_t Read(void* buffer, size_t bytes) const;
 
 	/// Peek into the stream
-	virtual size_t Peek(void *buffer, size_t bytes); 
+	virtual size_t Peek(void *buffer, size_t bytes) const;
 
 	/// Write to the stream
 	using Stream::Write;

--- a/Source/Core/StreamMemory.cpp
+++ b/Source/Core/StreamMemory.cpp
@@ -128,7 +128,7 @@ size_t StreamMemory::Read(void *_buffer, size_t bytes) const
 }
 
 // Read bytes from the buffer, not advancing the internal pointer
-size_t StreamMemory::Peek( void *_buffer, size_t bytes ) 
+size_t StreamMemory::Peek( void *_buffer, size_t bytes ) const
 {
 	bytes = Math::ClampUpper(bytes, (size_t) (buffer + buffer_used - buffer_ptr));
 


### PR DESCRIPTION
Peek is defined in base class as const as it should be, updating this declaration to match
