### PR TITLE
Removes usage of deprecated XKeycodeToKeysym function in X11 example.

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -240,6 +240,12 @@ if(BUILD_SAMPLES)
     	find_package(X11 REQUIRED)
         if (X11_FOUND)
         	list(APPEND sample_LIBRARIES ${X11_LIBRARIES})
+		# shell/src/x11/InputX11.cpp:InitialiseX11Keymap uses Xkb if
+		# possible instead of XGetKeyboardMapping for performance
+		if(X11_Xkb_FOUND)
+			FIND_PACKAGE_MESSAGE(X11 "Found X11 KBlib: ${X11_X11_LIB}" "[${X11_X11_LIB}][${X11_XkbINCLUDE_DIR}]")
+			add_definitions(-DHAS_X11XKBLIB)
+		endif()
         endif()
     endif()
    

--- a/Samples/shell/include/x11/InputX11.h
+++ b/Samples/shell/include/x11/InputX11.h
@@ -47,6 +47,11 @@ public:
 
 	/// Process the windows message
 	static void ProcessXEvent(Display* display, const XEvent& event);
+
+	// Initialises Xkb extension if available or reads keymap from X11
+	// server otherwise.  This is internal to the X11 subsystem and
+	// has nothing to do with libRocket's mapping.
+	static void InitialiseX11Keymap(Display *display);
 };
 
 #endif

--- a/Samples/shell/src/x11/ShellX11.cpp
+++ b/Samples/shell/src/x11/ShellX11.cpp
@@ -74,6 +74,11 @@ bool Shell::OpenWindow(const char* name, bool attach_opengl)
 	if (display == NULL)
 		return false;
 
+	// This initialise they keyboard to keycode mapping system of X11
+	// itself.  It must be done here as it needs to query the connected
+	// X server display for information about its install keymap abilities.
+	InputX11::InitialiseX11Keymap(display);
+
 	screen = XDefaultScreen(display);
 
 	// Fetch an appropriate 32-bit visual interface.


### PR DESCRIPTION
Provides proper example of key mapping for all versions of X11 since R5 to current, including preferred usage of Xkb extension for performance and fall back support for virtual frame buffers such as x11vnc.
