### PR TITLE
Fixes issue with dllimport inline on non Microsoft compilers for WIN32

### DIFF
--- a/Include/Rocket/Core/Header.h
+++ b/Include/Rocket/Core/Header.h
@@ -30,18 +30,56 @@
 
 #include <Rocket/Core/Platform.h>
 
+// Note: Changing a ROCKETCORE_API_INLINE method
+// breaks ABI compatibility!!
+
 #if !defined STATIC_LIB
 	#if defined ROCKET_PLATFORM_WIN32
 		#if defined RocketCore_EXPORTS
 			#define ROCKETCORE_API __declspec(dllexport)
+			// Note: Changing a ROCKETCORE_API_INLINE method
+			// breaks ABI compatibility!!
+			
+			// This results in an exported method from the DLL
+			// that may be inlined in DLL clients, or if not
+			// possible the client may choose to import the copy
+			// in the DLL if it can not be inlined.
+			#define ROCKETCORE_API_INLINE __declspec(dllexport) inline
 		#else
 			#define ROCKETCORE_API __declspec(dllimport)
+			// Note: Changing a ROCKETCORE_API_INLINE method
+			// breaks ABI compatibility!!
+
+			// Based on the warnngs emitted by GCC/MinGW if using
+			// dllimport and inline together, the information at
+			// http://msdn.microsoft.com/en-us/library/xa0d9ste.aspx
+			// using dllimport inline is tricky.
+			#if defined(_MSC_VER)
+				// VisualStudio dllimport inline is supported
+				// and may be expanded to inline code when the
+				// /Ob1 or /Ob2 options are given for inline
+				// expansion, or pulled from the DLL if it can
+				// not be inlined.
+				#define ROCKETCORE_API_INLINE __declspec(dllimport) inline
+			#else
+				// MinGW 32/64 dllimport inline is not supported
+				// and dllimport is ignored, so we avoid using
+				// it here to squelch compiler generated
+				// warnings.
+				#define ROCKETCORE_API_INLINE inline
+			#endif
 		#endif
 	#else
 		#define ROCKETCORE_API __attribute__((visibility("default")))
+		// Note: Changing a ROCKETCORE_API_INLINE method
+		// breaks ABI compatibility!!
+		#define ROCKETCORE_API_INLINE __attribute__((visibility("default"))) inline
 	#endif
 #else
 	#define ROCKETCORE_API
+	// Note: Changing a ROCKETCORE_API_INLINE method
+	// breaks ABI compatibility!!
+	#define ROCKETCORE_API_INLINE
 #endif
 
 #endif

--- a/Include/Rocket/Core/String.h
+++ b/Include/Rocket/Core/String.h
@@ -50,20 +50,24 @@ ROCKETCORE_API int StringBase<char>::FormatString(StringBase<char>::size_type ma
 ROCKETCORE_API String operator+(const char* cstring, const String& string);
 
 // partial specialization follows
+
+/* !!! CHANGING THIS METHOD BREAKS ABI COMPATIBILITY DUE TO INLINING !!! */
 template<>
-ROCKETCORE_API inline bool StringBase< char >::operator<(const char * compare) const
+ROCKETCORE_API_INLINE bool StringBase< char >::operator<(const char * compare) const
 {
 	return strcmp( value, compare ) < 0;
 }
 
+/* !!! CHANGING THIS METHOD BREAKS ABI COMPATIBILITY DUE TO INLINING !!! */
 template<>
-ROCKETCORE_API inline bool StringBase< char >::operator==(const char * compare) const
+ROCKETCORE_API_INLINE bool StringBase< char >::operator==(const char * compare) const
 {
 	return strcmp( value, compare ) == 0;
 }
 
+/* !!! CHANGING THIS METHOD BREAKS ABI COMPATIBILITY DUE TO INLINING !!! */
 template<>
-ROCKETCORE_API inline bool StringBase< char >::operator!=(const char * compare) const
+ROCKETCORE_API_INLINE bool StringBase< char >::operator!=(const char * compare) const
 {
 	return strcmp( value, compare ) != 0;
 }


### PR DESCRIPTION
dllimport inlining is only supported on Microsoft compilers.  Specifically, MinGW 32 does not support this feature.  This patch deals with the issue as gracefully as possible while maintains as much compatibility and feature support as possible.  It still works for MS compilers, but importing from a DLL for MinGW 32 inlines the function or includes its own instance of the method rather than importing the DLL method when it can not be inlined.

MS compilers will not create their own instanced of the method if it can be inlined and instead will refer to the instance in the DLL.
