### PR TITLE
better fix for PI

### DIFF
--- a/Include/Rocket/Core/Math.h
+++ b/Include/Rocket/Core/Math.h
@@ -34,15 +34,8 @@ namespace Rocket {
 namespace Core {
 namespace Math {
 
-// The constant PI / 2.
-extern ROCKETCORE_API const float PI_BY_TWO;
 // The constant PI.
-extern ROCKETCORE_API const float PI;
-// The constant 2 * PI / 3.
-extern ROCKETCORE_API const float TWO_PI_BY_THREE;
-// The constant 2 * PI.
-extern ROCKETCORE_API const float TWO_PI;
-
+extern ROCKETCORE_API const float ROCKET_PI;
 
 template < typename Type >
 Type Max(Type a, Type b)

--- a/Source/Core/Math.cpp
+++ b/Source/Core/Math.cpp
@@ -34,10 +34,7 @@ namespace Rocket {
 namespace Core {
 namespace Math {
 
-const float PI = 3.141592653f;
-const float PI_BY_TWO = PI * 0.5f;
-const float TWO_PI_BY_THREE = PI * 1.5f;
-const float TWO_PI = PI * 2;
+const float ROCKET_PI = 3.141592653f;
 
 static const float FZERO = 0.0001f;
 
@@ -99,19 +96,19 @@ ROCKETCORE_API float ATan2(float y, float x)
 // Converts an angle from radians to degrees.
 ROCKETCORE_API float RadiansToDegrees(float angle)
 {
-	return angle * (180.0f / PI);
+	return angle * (180.0f / ROCKET_PI);
 }
 
 // Converts an angle from degrees to radians.
 ROCKETCORE_API float DegreesToRadians(float angle)
 {
-	return angle * (PI / 180.0f);
+	return angle * (ROCKET_PI / 180.0f);
 }
 
 // Normalises and angle in radians
 ROCKETCORE_API float NormaliseAngle(float angle)
 {
-	return fmodf(angle, TWO_PI);
+	return fmodf(angle, ROCKET_PI * 2.0);
 }
 
 // Calculates the square root of a value.


### PR DESCRIPTION
see #66 

Changed name + removed variants, as only TWO_PI was ever used, and even then it was only used once.

@dwimsey good to go?
Also, sorry I've been really busy the last while, just moved out and started a new job, will try get back at libRocket
