### PR TITLE
Minor fix to the way python modules are built

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -153,7 +153,7 @@ if(BUILD_PYTHON_BINDINGS)
     foreach(library ${LIBRARIES})
         set(NAME _rocket${library})
 
-        add_library(${NAME} ${Py${library}_SRC_FILES}
+        add_library(${NAME} MODULE ${Py${library}_SRC_FILES}
                             ${Py${library}_HDR_FILES}
                             ${Py${library}_PUB_HDR_FILES}
         )


### PR DESCRIPTION
This change causes python modules _rocketcore and _rocketcontrol to be built as shared objects/DLLs regardless of the setting of BUILD_SHARED_LIBS to cmake.

It also avoids linking the _rocketcore and _rocketcontrols to any other libraries or executables in the project.  The standard STATIC or SHARED methods will link the python modules to other executables directly rather than letting them be loaded dynamically at runtime as needed.

Intended to eventually allow -DBUILD_SHARED_LIBS=off and -DBUILD_PYTHON_BINDINGS=ON to work together nicely.
