### PR TITLE
Hotfix for broken static library builds

### DIFF
--- a/Include/Rocket/Core/Header.h
+++ b/Include/Rocket/Core/Header.h
@@ -79,7 +79,7 @@
 	#define ROCKETCORE_API
 	// Note: Changing a ROCKETCORE_API_INLINE method
 	// breaks ABI compatibility!!
-	#define ROCKETCORE_API_INLINE
+	#define ROCKETCORE_API_INLINE inline
 #endif
 
 #endif


### PR DESCRIPTION
Pull request #163 was not properly checked and broke static builds, this resolves that issue.

The issue is that the inline qualifier was removed from static builds using ROCKET_API_INLINE when it shouldn't have been.   The result is that any API call which used ROCKET_API_INLINE will result in multiple definitions for each time it is used when compiling staticly.
