### PR TITLE
fixed bug that cause invaders sample to be unable to run

### DIFF
--- a/Samples/shell/src/win32/ShellWin32.cpp
+++ b/Samples/shell/src/win32/ShellWin32.cpp
@@ -137,14 +137,6 @@ bool Shell::OpenWindow(const char* name, ShellRenderInterfaceExtensions *_shell_
 	SetWindowLong(window_handle, GWL_EXSTYLE, extended_style);
 	SetWindowLong(window_handle, GWL_STYLE, style);
 
-	// Resize the window.
-	SetWindowPos(window_handle, HWND_TOP, 0, 0, window_rect.right - window_rect.left, window_rect.bottom - window_rect.top, SWP_NOACTIVATE);
-
-	// Display the new window
-	ShowWindow(window_handle, SW_SHOW);
-	SetForegroundWindow(window_handle);
-	SetFocus(window_handle);
-
 	if (_shell_renderer != NULL)
 	{
 		shell_renderer = _shell_renderer;
@@ -154,6 +146,14 @@ bool Shell::OpenWindow(const char* name, ShellRenderInterfaceExtensions *_shell_
 			return false;
 		}
 	}
+
+	// Resize the window.
+	SetWindowPos(window_handle, HWND_TOP, 0, 0, window_rect.right - window_rect.left, window_rect.bottom - window_rect.top, SWP_NOACTIVATE);
+
+	// Display the new window
+	ShowWindow(window_handle, SW_SHOW);
+	SetForegroundWindow(window_handle);
+	SetFocus(window_handle);
 
     return true;
 }


### PR DESCRIPTION
So if it had worked on VS2012, my guess is that is problem is specific to VS2013.

When running the "invaders" example in debug mode I saw this error: 

"Unhandled exception at 0x00BAAF84 in invaders.exe: 0xC000041D: An unhandled exception was encountered during a user callback."

which occured at Samples/shell/src/win32/ShellWin32.cpp at line 283:

```
shell_renderer->SetViewport(width, height);
```

called from line 141:

```
SetWindowPos(window_handle, HWND_TOP, 0, 0, window_rect.right - window_rect.left, window_rect.bottom - window_rect.top, SWP_NOACTIVATE);
```

So it turned out shell_renderer had not be initialized and was therefore NULL when called at that point. I then figured that the code block:

```
if (_shell_renderer != NULL)
{
    shell_renderer = _shell_renderer;
    if(!shell_renderer->AttachToNative(window_handle))
    {
        CloseWindow();
        return false;
    }
}
```

initializes shell_renderer. Placing it before line 141 therefore solves this problem.

VS2013-32bit, Windows 8.1
