### PR TITLE
fixed gl.h compile time errors in VS2013 (SFML2 sample)

### DIFF
--- a/Samples/basic/sfml2/src/RenderInterfaceSFML.h
+++ b/Samples/basic/sfml2/src/RenderInterfaceSFML.h
@@ -42,8 +42,10 @@
 // if the OpenGL Extension Wrangler Library (GLEW) should not be used
 // include the standard OpenGL library
 #ifndef ENABLE_GLEW
+#ifdef _MSC_VER 
 // NOTE: add this if you receive a lot of errors in gl.h
-//#include <windows.h>
+#include <windows.h>
+#endif
 #include <GL/gl.h>
 #endif
 


### PR DESCRIPTION
according to http://stackoverflow.com/questions/430413/vc-compile-errors-when-including-gl-h the gl.h errors are specific to VC++, there placing a condition there elimates the for VC++ people to uncomment

```
#include <windows.h>
```
