### PR TITLE
bug fix: SFML2 example runtime error when application closes

### DIFF
--- a/Samples/basic/sfml2/src/main.cpp
+++ b/Samples/basic/sfml2/src/main.cpp
@@ -155,13 +155,16 @@ int main(int argc, char **argv)
 					SystemInterface.GetKeyModifiers(&MyWindow));
 				break;
 			case sf::Event::Closed:
-				return 1;
+				MyWindow.close();
 				break;
 			};
 		};
 
 		Context->Update();
 	};
+
+	Context->RemoveReference();
+	Rocket::Core::Shutdown();
 
 	return 0;
 };


### PR DESCRIPTION
in VS2013, the SFML2 example will run fine, but when it is closed...

![2014-08-24 23_00_38-microsoft visual c runtime library](https://cloud.githubusercontent.com/assets/3065980/4023680/7baa0d80-2b9f-11e4-9c11-d51b7375198a.png)

The call stack is as follows:

![2014-08-24 23_03_45-sfml2 debugging - microsoft visual studio](https://cloud.githubusercontent.com/assets/3065980/4023692/eb8b0df2-2b9f-11e4-9853-8b96da095659.png)

It turned out that there are references still lying around the program that were not disposed when the program terminates. When I compared to the other examples, I noticed this example did not have the lines:

```
Context->RemoveReference();
Rocket::Core::Shutdown();
```

Making sure that these 2 lines are executed when the program terminates ensures that libRocket has been properly shutdown at program termination.
