### PR TITLE
Fix memory leak with ReferenceCountable objects

### DIFF
--- a/Source/Core/Lua/Document.cpp
+++ b/Source/Core/Lua/Document.cpp
@@ -102,7 +102,8 @@ int DocumentCreateElement(lua_State* L, Document* obj)
 {
     const char* tag = luaL_checkstring(L,1);
     Element* ele = obj->CreateElement(tag);
-    LuaType<Element>::push(L,ele,false);
+    LuaType<Element>::push(L,ele,true);
+    ele->RemoveReference();
     return 1;
 }
 
@@ -111,7 +112,8 @@ int DocumentCreateTextNode(lua_State* L, Document* obj)
     //need ElementText object first
     const char* text = luaL_checkstring(L,1);
     ElementText* et = obj->CreateTextNode(text);
-    LuaType<ElementText>::push(L, et, false);
+    LuaType<ElementText>::push(L, et, true);
+    et->RemoveReference();
 	return 1;
 }
 

--- a/Source/Core/Lua/LuaElementInstancer.cpp
+++ b/Source/Core/Lua/LuaElementInstancer.cpp
@@ -27,6 +27,7 @@
 
 #include "precompiled.h"
 #include "LuaElementInstancer.h"
+#include <Rocket/Core/Platform.h>
 #include <Rocket/Core/Lua/LuaType.h>
 #include <Rocket/Core/Lua/Interpreter.h>
 #include <Rocket/Core/Log.h>


### PR DESCRIPTION
When document:CreateElement or document:CreateTextNode was called in Lua, the elements would never have their references removed. Now the references are properly accounted for.

Things I learned while I was fixing this:

The Lua plugin requires a different lifetime compared to what the plugin api offers. You must destroy all contexts before calling Rocket::Core::Shutdown. However, if you wait until then to shutdown Lua, then Elements created or used in Lua will still have reference counts > 0. The destructor of an element can destroy compiled geometry, which checks its parent context for the render interface (which will not exist if context is destroyed before Lua is shutdown). 

In short, make sure you shut down Lua before you close contexts for now. In a later update, I am considering making one Lua State per document (similar to javascript in html), but I have to look in to the unloading order and reference counting there a little deeper to see if it will fix that.
