### PR TITLE
Lua sometimes crashing on application exit

### DIFF
--- a/Include/Rocket/Core/Lua/Interpreter.h
+++ b/Include/Rocket/Core/Lua/Interpreter.h
@@ -85,7 +85,7 @@ public:
     static void RegisterCoreTypes(lua_State* L);
 
     /** 
-    @return The lua_State that the Interpreter created in Interpreter::Startup()
+    @return The lua_State that the Interpreter created in Interpreter::Startup(), or NULL if shutdown
     @remark This class lacks a SetLuaState for a reason. If you have to use a seperate Lua binding and want to keep the types
     from libRocket, then use this lua_State; it will already have all of the libraries loaded, and all of the types defined.
     Alternatively, you can call RegisterCoreTypes(lua_State*) with your own Lua state if you need them defined in it. */

--- a/Samples/luainvaders/src/main.cpp
+++ b/Samples/luainvaders/src/main.cpp
@@ -134,15 +134,15 @@ int main(int, char**)
 
 	Shell::EventLoop(GameLoop);	
 
-	// Shutdown the Rocket contexts.	
-	context->RemoveReference();
-	
-	// Shutdown Lua  before we shut down Rocket.
-	Rocket::Core::Lua::Interpreter::Shutdown();
-
 	// Shut down the game singletons.
 	HighScores::Shutdown();
 
+	// Shutdown Lua  before we shut down Rocket.
+	Rocket::Core::Lua::Interpreter::Shutdown();
+
+	// Shutdown the Rocket contexts.	
+	context->RemoveReference();
+	
 	// Shutdown Rocket.
 	Rocket::Core::Shutdown();
 

--- a/Source/Controls/Lua/LuaDataFormatter.cpp
+++ b/Source/Controls/Lua/LuaDataFormatter.cpp
@@ -54,6 +54,8 @@ void LuaDataFormatter::FormatData(Rocket::Core::String& formatted_data, const Ro
         return;
     }
     lua_State* L = Interpreter::GetLuaState();
+    if(L == NULL) //Lua is shutdown already
+        return;
     int top = lua_gettop(L);
     PushDataFormatterFunctionTable(L); // push the table where the function resides
     lua_rawgeti(L,-1,ref_FormatData); //push the function

--- a/Source/Controls/Lua/LuaDataSource.cpp
+++ b/Source/Controls/Lua/LuaDataSource.cpp
@@ -54,6 +54,8 @@ void LuaDataSource::GetRow(Rocket::Core::StringList& row, const Rocket::Core::St
     //setup the call
     Interpreter::BeginCall(getRowRef);
     lua_State* L = Interpreter::GetLuaState();
+    if(L == NULL) //Lua is shutdown already
+        return;
     lua_pushstring(L,table.CString());
     lua_pushinteger(L,row_index);
     lua_newtable(L);
@@ -91,6 +93,8 @@ int LuaDataSource::GetNumRows(const Rocket::Core::String& table)
     if(getNumRowsRef == LUA_NOREF || getNumRowsRef == LUA_REFNIL) return -1;
 
     lua_State* L = Interpreter::GetLuaState();
+    if(L == NULL) //Lua is shutdown already
+        return -1;
     Interpreter::BeginCall(getNumRowsRef);
     lua_pushstring(L,table.CString());
     Interpreter::ExecuteCall(1,1); //1 parameter, 1 return. After this, the top of the stack contains the return value

--- a/Source/Core/Lua/Interpreter.cpp
+++ b/Source/Core/Lua/Interpreter.cpp
@@ -235,6 +235,7 @@ void Interpreter::Initialise(lua_State *luaStatePointer)
 void Interpreter::Shutdown()
 {
 	lua_close(_L);
+    _L = NULL;
 }
 
 

--- a/Source/Core/Lua/LuaElementInstancer.cpp
+++ b/Source/Core/Lua/LuaElementInstancer.cpp
@@ -55,6 +55,8 @@ Element* LuaElementInstancer::InstanceElement(Element* ROCKET_UNUSED_PARAMETER(p
     ROCKET_UNUSED(attributes);
 
     lua_State* L = Interpreter::GetLuaState();
+    if(L == NULL) //Lua is shutdown already
+        return NULL;
     int top = lua_gettop(L);
     Element* ret = NULL;
     if(ref_InstanceElement != LUA_REFNIL && ref_InstanceElement != LUA_NOREF)

--- a/Source/Core/Lua/LuaEventListener.cpp
+++ b/Source/Core/Lua/LuaEventListener.cpp
@@ -45,6 +45,8 @@ LuaEventListener::LuaEventListener(const String& code, Element* element) : Event
 
     //make sure there is an area to save the function
     lua_State* L = Interpreter::GetLuaState();
+    if(L == NULL) //Lua is shutdown already
+        return;
     int top = lua_gettop(L);
     lua_getglobal(L,"EVENTLISTENERFUNCTIONS");
     if(lua_isnoneornil(L,-1))
@@ -122,6 +124,8 @@ void LuaEventListener::ProcessEvent(Event& event)
     //correct that
     if(!parent && attached) parent = attached->GetOwnerDocument();
     lua_State* L = Interpreter::GetLuaState();
+    if(L == NULL) //Lua is shutdown already
+        return;
     int top = lua_gettop(L); 
 
     //push the arguments


### PR DESCRIPTION
Now that Lua respects C++ reference counts, the shutdown order is switched (Lua shutdown before context is released and Core shutdown). This PR fixes that for the Lua Invaders sample.

Sometimes (like in the case of the luainvaders sample), some of the C++ references to Lua (ex LuaEventListener) would stick around after the Lua interpreter had shutdown, which crashed the application when exited. This should fix that issue as well.
