### PR TITLE
Toggle CMake policy CMP0042 on by default

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -18,6 +18,18 @@ if(COMMAND cmake_policy)
   cmake_policy(SET CMP0015 NEW)
 endif(COMMAND cmake_policy)
 
+# Enable the use of MACOSX_RPATH by default for CMake v3.0+; this effectively 
+# allows plug 'n' play functionality, so to speak -- the resulting shared 
+# library files can simply be copied over into the end-user's application 
+# bundle or framework bundle. No mucking around with install_name_tool.
+#
+# 	See also: 
+# cmake --help-policy cmp0042
+# http://www.kitware.com/blog/home/post/510
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+endif(POLICY CMP0042)
+
 project(libRocket C CXX)
 
 # paths


### PR DESCRIPTION
This resolves the project developer warning notice I get from CMake upon generating project files. It is set to prefer the new (v3.0+) CMake policy regarding the use of MACOSX_RPATH. The rationale for this is is ease of use with the resulting built library files under OSX -- it allows me to simply copy the dynamic library files over to my project's dependencies directory path, and be done with it.

This commit does not take into consideration the recent OSX framework bundle feature that has been added, but I do believe that the two _should_ work seamlessly together.
