### PR TITLE
Fix for OS X build - Freetype / Mono collision

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -191,7 +191,10 @@ if(CMAKE_MAJOR_VERSION LESS 3)
 	# the FindFreetype module from cmake v3 at least, included here
 	find_package(Freetype-v2fix REQUIRED)	
 else()
-	find_package(Freetype REQUIRED)	
+	set(PREV_CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK})
+	set(CMAKE_FIND_FRAMEWORK LAST)
+	find_package(Freetype REQUIRED)
+	set(CMAKE_FIND_FRAMEWORK ${PREV_CMAKE_FIND_FRAMEWORK})
 endif()
 
 if(FREETYPE_FOUND)


### PR DESCRIPTION
Mono.framework was matching for libfreetype on OS X, this little workaround lowers the priority of a framework match.