### PR TITLE
Round ppi units up

### DIFF
--- a/Source/Core/Decorator.cpp
+++ b/Source/Core/Decorator.cpp
@@ -126,15 +126,15 @@ float Decorator::ResolveProperty(const PropertyDictionary& properties, const Str
 		float inch = property->value.Get< float >() * GetRenderInterface()->GetPixelsPerInch();
 
 		if (property->unit & Property::INCH) // inch
-			return inch;
+			return Math::Round(inch);
 		if (property->unit & Property::CM) // centimeter
-			return inch / 2.54f;
+			return Math::Round(inch * (1.0f / 2.54f));
 		if (property->unit & Property::MM) // millimeter
-			return inch / 25.4f;
+			return Math::Round(inch * (1.0f / 25.4f));
 		if (property->unit & Property::PT) // point
-			return inch / 72.0f;
+			return Math::Round(inch * (1.0f / 72.0f));
 		if (property->unit & Property::PC) // pica
-			return inch / 6.0f;
+			return Math::Round(inch * (1.0f / 6.0f));
 	}
 
 	ROCKET_ERROR;

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -371,15 +371,15 @@ float ElementStyle::ResolveProperty(const Property* property, float base_value)
 		float inch = property->value.Get< float >() * element->GetRenderInterface()->GetPixelsPerInch();
 		
 		if (property->unit & Property::INCH) // inch
-			return inch;
+			return Math::Round(inch);
 		if (property->unit & Property::CM) // centimeter
-			return inch * (1.0f / 2.54f);
+			return Math::Round(inch * (1.0f / 2.54f));
 		if (property->unit & Property::MM) // millimeter
-			return inch * (1.0f / 25.4f);
+			return Math::Round(inch * (1.0f / 25.4f));
 		if (property->unit & Property::PT) // point
-			return inch * (1.0f / 72.0f);
+			return Math::Round(inch * (1.0f / 72.0f));
 		if (property->unit & Property::PC) // pica
-			return inch * (1.0f / 6.0f);
+			return Math::Round(inch * (1.0f / 6.0f));
 	}
 
 	// We're not a numeric property; return 0.
@@ -459,15 +459,15 @@ float ElementStyle::ResolveProperty(const String& name, float base_value)
 		float inch = property->value.Get< float >() * element->GetRenderInterface()->GetPixelsPerInch();
 
 		if (property->unit & Property::INCH) // inch
-			return inch;
+			return Math::Round(inch);
 		if (property->unit & Property::CM) // centimeter
-			return inch / 2.54f;
+			return Math::Round(inch * (1.0f / 2.54f));
 		if (property->unit & Property::MM) // millimeter
-			return inch / 25.4f;
+			return Math::Round(inch * (1.0f / 25.4f));
 		if (property->unit & Property::PT) // point
-			return inch / 72.0f;
+			return Math::Round(inch * (1.0f / 72.0f));
 		if (property->unit & Property::PC) // pica
-			return inch / 6.0f;
+			return Math::Round(inch * (1.0f / 6.0f));
 	}
 
 	// We're not a numeric property; return 0.


### PR DESCRIPTION
This pull request makes properties relative to inches be rounded up when resolved.

One of uses for the real-life units is mobile devices, however, there are devices with the DPI lower than the base one, so for instance, if you make a 1pt border, it will disappear on screens below the base DPI.