### PR TITLE
Allow fonts to be uploaded as 8bpp textures to save on video RAM

### DIFF
--- a/Include/Rocket/Core/RenderInterface.h
+++ b/Include/Rocket/Core/RenderInterface.h
@@ -97,10 +97,11 @@ public:
 	virtual bool LoadTexture(TextureHandle& texture_handle, Vector2i& texture_dimensions, const String& source);
 	/// Called by Rocket when a texture is required to be built from an internally-generated sequence of pixels.
 	/// @param[out] texture_handle The handle to write the texture handle for the generated texture to.
-	/// @param[in] source The raw 8-bit texture data. Each pixel is made up of four 8-bit values, indicating red, green, blue and alpha in that order.
+	/// @param[in] source The raw 8-bit texture data. Each pixel is made up of texture_samples 8-bit values.
 	/// @param[in] source_dimensions The dimensions, in pixels, of the source data.
+	/// @param[in] source_samples Pixel size of the texture data, in bytes.
 	/// @return True if the texture generation succeeded and the handle is valid, false if not.
-	virtual bool GenerateTexture(TextureHandle& texture_handle, const byte* source, const Vector2i& source_dimensions);
+	virtual bool GenerateTexture(TextureHandle& texture_handle, const byte* source, const Vector2i& source_dimensions, int source_samples);
 	/// Called by Rocket when a loaded texture is no longer required.
 	/// @param texture The texture handle to release.
 	virtual void ReleaseTexture(TextureHandle texture);

--- a/Source/Core/ConvolutionFilter.cpp
+++ b/Source/Core/ConvolutionFilter.cpp
@@ -115,7 +115,11 @@ void ConvolutionFilter::Run(byte* destination, const Vector2i& destination_dimen
 				opacity /= num_pixels;
 
 			opacity = Math::Min(255, opacity);
+#ifdef ROCKET_8BPP_FONTS
+			destination[x] = (byte) opacity;
+#else
 			destination[x * 4 + 3] = (byte) opacity;
+#endif
 		}
 
 		destination += destination_stride;

--- a/Source/Core/FontFaceHandle.cpp
+++ b/Source/Core/FontFaceHandle.cpp
@@ -246,13 +246,13 @@ int FontFaceHandle::GenerateLayerConfiguration(FontEffectMap& font_effects)
 }
 
 // Generates the texture data for a layer (for the texture database).
-bool FontFaceHandle::GenerateLayerTexture(const byte*& texture_data, Vector2i& texture_dimensions, FontEffect* layer_id, int texture_id)
+bool FontFaceHandle::GenerateLayerTexture(const byte*& texture_data, Vector2i& texture_dimensions, int &texture_samples, FontEffect* layer_id, int texture_id)
 {
 	FontLayerMap::iterator layer_iterator = layers.find(layer_id);
 	if (layer_iterator == layers.end())
 		return false;
 
-	return layer_iterator->second->GenerateTexture(texture_data, texture_dimensions, texture_id);
+	return layer_iterator->second->GenerateTexture(texture_data, texture_dimensions, texture_samples, texture_id);
 }
 
 // Generates the geometry required to render a single line of text.

--- a/Source/Core/FontFaceHandle.h
+++ b/Source/Core/FontFaceHandle.h
@@ -96,9 +96,10 @@ public:
 	/// Generates the texture data for a layer (for the texture database).
 	/// @param[out] texture_data The pointer to be set to the generated texture data.
 	/// @param[out] texture_dimensions The dimensions of the texture.
+	/// @param[out] texture_samples Pixel size of the texture, in bytes.
 	/// @param[in] layer_id The id of the layer to request the texture data from.
 	/// @param[in] texture_id The index of the texture within the layer to generate.
-	bool GenerateLayerTexture(const byte*& texture_data, Vector2i& texture_dimensions, FontEffect* layer_id, int texture_id);
+	bool GenerateLayerTexture(const byte*& texture_data, Vector2i& texture_dimensions, int &texture_samples, FontEffect* layer_id, int texture_id);
 
 	/// Generates the geometry required to render a single line of text.
 	/// @param[out] geometry An array of geometries to generate the geometry into.

--- a/Source/Core/FontFaceLayer.h
+++ b/Source/Core/FontFaceLayer.h
@@ -65,9 +65,10 @@ public:
 	/// Generates the texture data for a layer (for the texture database).
 	/// @param[out] texture_data The pointer to be set to the generated texture data.
 	/// @param[out] texture_dimensions The dimensions of the texture.
+	/// @param[out] texture_samples Pixel size of the texture, in bytes.
 	/// @param[in] glyphs The glyphs required by the font face handle.
 	/// @param[in] texture_id The index of the texture within the layer to generate.
-	bool GenerateTexture(const byte*& texture_data, Vector2i& texture_dimensions, int texture_id);
+	bool GenerateTexture(const byte*& texture_data, Vector2i& texture_dimensions, int &texture_samples, int texture_id);
 	/// Generates the geometry required to render a single character.
 	/// @param[out] geometry An array of geometries this layer will write to. It must be at least as big as the number of textures in this layer.
 	/// @param[in] character_code The character to generate geometry for.

--- a/Source/Core/RenderInterface.cpp
+++ b/Source/Core/RenderInterface.cpp
@@ -77,11 +77,13 @@ bool RenderInterface::LoadTexture(TextureHandle& ROCKET_UNUSED_PARAMETER(texture
 }
 
 // Called by Rocket when a texture is required to be built from an internally-generated sequence of pixels.
-bool RenderInterface::GenerateTexture(TextureHandle& ROCKET_UNUSED_PARAMETER(texture_handle), const byte* ROCKET_UNUSED_PARAMETER(source), const Vector2i& ROCKET_UNUSED_PARAMETER(source_dimensions))
+bool RenderInterface::GenerateTexture(TextureHandle& ROCKET_UNUSED_PARAMETER(texture_handle), const byte* ROCKET_UNUSED_PARAMETER(source), const Vector2i& ROCKET_UNUSED_PARAMETER(source_dimensions),
+	int ROCKET_UNUSED_PARAMETER(source_samples))
 {
 	ROCKET_UNUSED(texture_handle);
 	ROCKET_UNUSED(source);
 	ROCKET_UNUSED(source_dimensions);
+	ROCKET_UNUSED(source_samples);
 	
 	return false;
 }

--- a/Source/Core/TextureLayout.cpp
+++ b/Source/Core/TextureLayout.cpp
@@ -87,7 +87,7 @@ int TextureLayout::GetNumTextures() const
 }
 
 // Attempts to generate an efficient texture layout for the rectangles.
-bool TextureLayout::GenerateLayout(int max_texture_dimensions)
+bool TextureLayout::GenerateLayout(int max_texture_dimensions, int samples)
 {
 	// Sort the rectangles by height.
 	std::sort(rectangles.begin(), rectangles.end(), RectangleSort());
@@ -95,7 +95,7 @@ bool TextureLayout::GenerateLayout(int max_texture_dimensions)
 	int num_placed_rectangles = 0;
 	while (num_placed_rectangles != GetNumRectangles())
 	{
-		TextureLayoutTexture texture;
+		TextureLayoutTexture texture(samples);
 		int texture_size = texture.Generate(*this, max_texture_dimensions);
 		if (texture_size == 0)
 			return false;

--- a/Source/Core/TextureLayout.h
+++ b/Source/Core/TextureLayout.h
@@ -71,8 +71,9 @@ public:
 
 	/// Attempts to generate an efficient texture layout for the rectangles.
 	/// @param[in] max_texture_dimensions The maximum dimensions allowed for any single texture.
+	/// @param[in] samples Pixel size of texture data, in bytes.
 	/// @return True if the layout was generated successfully, false if not.
-	bool GenerateLayout(int max_texture_dimensions);
+	bool GenerateLayout(int max_texture_dimensions, int samples);
 
 private:
 	typedef std::vector< TextureLayoutRectangle > RectangleList;

--- a/Source/Core/TextureLayoutRectangle.cpp
+++ b/Source/Core/TextureLayoutRectangle.cpp
@@ -82,10 +82,11 @@ bool TextureLayoutRectangle::IsPlaced() const
 }
 
 // Sets the rectangle's texture data and stride.
-void TextureLayoutRectangle::Allocate(byte* _texture_data, int _texture_stride)
+void TextureLayoutRectangle::Allocate(byte* _texture_data, int _texture_stride, int _texture_samples)
 {
-	texture_data = _texture_data + ((texture_position.y * _texture_stride) + texture_position.x * 4);
+	texture_data = _texture_data + ((texture_position.y * _texture_stride) + texture_position.x * _texture_samples);
 	texture_stride = _texture_stride;
+	texture_samples = _texture_samples;
 }
 
 // Returns the index of the texture this rectangle is placed on.

--- a/Source/Core/TextureLayoutRectangle.h
+++ b/Source/Core/TextureLayoutRectangle.h
@@ -66,7 +66,8 @@ public:
 	/// Sets the rectangle's texture data and stride.
 	/// @param[in] texture_data The pointer to the top-left corner of the texture's data.
 	/// @param[in] texture_stride The stride of the texture data, in bytes.
-	void Allocate(byte* texture_data, int texture_stride);
+	/// @param[in] texture_samples Pixel size of the texture data, in bytes.
+	void Allocate(byte* texture_data, int texture_stride, int texture_samples);
 
 	/// Returns the index of the texture this rectangle is placed on.
 	/// @return The texture index.
@@ -87,6 +88,7 @@ private:
 
 	byte* texture_data;
 	int texture_stride;
+	int texture_samples;
 };
 
 }

--- a/Source/Core/TextureLayoutRow.cpp
+++ b/Source/Core/TextureLayoutRow.cpp
@@ -87,10 +87,10 @@ int TextureLayoutRow::Generate(TextureLayout& layout, int max_width, int y)
 }
 
 // Assigns allocated texture data to all rectangles in this row.
-void TextureLayoutRow::Allocate(byte* texture_data, int stride)
+void TextureLayoutRow::Allocate(byte* texture_data, int stride, int samples)
 {
 	for (size_t i = 0; i < rectangles.size(); ++i)
-		rectangles[i]->Allocate(texture_data, stride);
+		rectangles[i]->Allocate(texture_data, stride, samples);
 }
 
 // Returns the height of the row.

--- a/Source/Core/TextureLayoutRow.h
+++ b/Source/Core/TextureLayoutRow.h
@@ -57,7 +57,8 @@ public:
 	/// Assigns allocated texture data to all rectangles in this row.
 	/// @param[in] texture_data The pointer to the beginning of the texture's data.
 	/// @param[in] stride The stride of the texture's surface, in bytes;
-	void Allocate(byte* texture_data, int stride);
+	/// @param[in] samples Pixel size of the texture, in bytes;
+	void Allocate(byte* texture_data, int stride, int samples);
 
 	/// Returns the height of the row.
 	/// @return The row's height.

--- a/Source/Core/TextureLayoutTexture.cpp
+++ b/Source/Core/TextureLayoutTexture.cpp
@@ -34,9 +34,9 @@
 namespace Rocket {
 namespace Core {
 
-TextureLayoutTexture::TextureLayoutTexture() : dimensions(0, 0)
+TextureLayoutTexture::TextureLayoutTexture(int samples) : 
+	dimensions(0, 0), texture_data(NULL), samples(samples)
 {
-	texture_data = NULL;
 }
 
 TextureLayoutTexture::~TextureLayoutTexture()
@@ -143,14 +143,21 @@ byte* TextureLayoutTexture::AllocateTexture()
 	if (dimensions.x > 0 &&
 		dimensions.y > 0)
 	{
-		texture_data = new byte[dimensions.x * dimensions.y * 4];
+		texture_data = new byte[dimensions.x * dimensions.y * samples];
 
 		// Set the texture to transparent white.
-		for (int i = 0; i < dimensions.x * dimensions.y; i++)
-			((unsigned int*)(texture_data))[i] = 0x00ffffff;
+		switch (samples) {
+			case 4:
+				for (int i = 0; i < dimensions.x * dimensions.y; i++)
+					((unsigned int*)(texture_data))[i] = 0x00ffffff;
+				break;
+			default:
+				memset(texture_data, 255, dimensions.x * dimensions.y * samples);
+				break;
+		}
 
 		for (size_t i = 0; i < rows.size(); ++i)
-			rows[i].Allocate(texture_data, dimensions.x * 4);
+			rows[i].Allocate(texture_data, dimensions.x * samples, samples);
 	}
 
 	return texture_data;

--- a/Source/Core/TextureLayoutTexture.h
+++ b/Source/Core/TextureLayoutTexture.h
@@ -47,7 +47,7 @@ class TextureResource;
 class TextureLayoutTexture
 {
 public:
-	TextureLayoutTexture();
+	TextureLayoutTexture(int samples = 4);
 	~TextureLayoutTexture();
 
 	/// Returns the texture's dimensions. This is only valid after the texture has been generated.
@@ -72,6 +72,7 @@ private:
 	RowList rows;
 
 	byte* texture_data;
+	int samples;
 };
 
 }

--- a/Source/Core/TextureResource.cpp
+++ b/Source/Core/TextureResource.cpp
@@ -123,6 +123,7 @@ bool TextureResource::Load(RenderInterface* render_interface) const
 
 		bool delete_data = false;
 		const byte* data = NULL;
+		int samples = 4;
 
 		// Find the generation protocol and generate the data accordingly.
 		String protocol = source.Substring(1, source.Find("::") - 1);
@@ -139,6 +140,7 @@ bool TextureResource::Load(RenderInterface* render_interface) const
 			{
 				handle->GenerateLayerTexture(data,
 											 dimensions,
+											 samples,
 											 layer_id,
 											 texture_id);
 			}
@@ -149,7 +151,7 @@ bool TextureResource::Load(RenderInterface* render_interface) const
 		if (data != NULL)
 		{
 			TextureHandle handle;
-			bool success = render_interface->GenerateTexture(handle, data, dimensions);
+			bool success = render_interface->GenerateTexture(handle, data, dimensions, samples);
 
 			if (delete_data)
 				delete[] data;


### PR DESCRIPTION
This is a compile-time option, pass preprocessor ROCKET_8BPP_FONTS option to enable 8bpp fonts