### PR TITLE
When tabbing to a new element, make sure it is visible

### DIFF
--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -492,6 +492,7 @@ bool ElementDocument::SearchFocusSubtree(Element* element, bool forward)
 	if (element->GetProperty<int>(TAB_INDEX) == TAB_INDEX_AUTO)
 	{
 		element->Focus();
+		element->ScrollIntoView(false);
 		return true;
 	}
 


### PR DESCRIPTION
In console-like use you move with tabbing exclusively, ie. no mouse.