### PR TITLE
Remove a performance optimization to improve thread and exception safety...

### DIFF
--- a/Source/Core/String.cpp
+++ b/Source/Core/String.cpp
@@ -29,33 +29,41 @@
 #include "../../Include/Rocket/Core/String.h"
 #include "../../Include/Rocket/Core/StringBase.h"
 
+#include <memory>
+
 namespace Rocket {
 namespace Core {
 
 int ROCKETCORE_API RocketStringFormatString(StringBase<char>& string, int max_size, const char* format, va_list argument_list)
 {
-	const int INTERNAL_BUFFER_SIZE = 1024;
-	static char buffer[INTERNAL_BUFFER_SIZE];
-	char* buffer_ptr = buffer;
+	const int INTERNAL_BUFFER_SIZE = 2048;
+    int length = 0;
 
-	if (max_size + 1 > INTERNAL_BUFFER_SIZE)
-		buffer_ptr = new char[max_size + 1];
-
-	int length = vsnprintf(buffer_ptr, max_size, format, argument_list);
-	buffer_ptr[length >= 0 ? length : max_size] = '\0';
-	#ifdef ROCKET_DEBUG
-		if (length == -1)
-		{
-			Log::Message(Log::LT_WARNING, "String::sprintf: String truncated to %d bytes when processing %s", max_size, format);
-		}
-	#endif
-
-	string = buffer_ptr;
-
-	if (buffer_ptr != buffer)
-		delete[] buffer_ptr;
-
-	return length;
+    if (max_size + 1 > INTERNAL_BUFFER_SIZE)
+    {
+        // Prefer this for C++14
+        // auto buffer_ptr = std::make_unique<char[]>(max_size + 1);
+        std::unique_ptr<char[]> buffer_ptr(new char[max_size + 1]);
+        int length = vsnprintf(buffer_ptr.get(), max_size, format, argument_list);
+        buffer_ptr[length >= 0 ? length : max_size] = '\0';
+        string = buffer_ptr.get();
+        return length;
+    }
+    else
+    {
+        char buffer[INTERNAL_BUFFER_SIZE];
+        int length = vsnprintf(buffer, max_size, format, argument_list);
+        buffer[length >= 0 ? length : max_size] = '\0';
+        string = buffer;
+        return length;
+    }
+#ifdef ROCKET_DEBUG
+    if (length == -1)
+    {
+        Log::Message(Log::LT_WARNING, "String::sprintf: String truncated to %d bytes when processing %s", max_size, format);
+    }
+#endif
+    return length;
 }
 
 template <>


### PR DESCRIPTION
....

The format routine was using an internal static buffer presumably in order to reduce dynamic memory allocations and hopefully gain a performance win. Though noble, this optimization comes at the expense of safety.

IMO a user of such a common and seemingly harmless routine as a formatting function would not expect to loose thread safety just to do string formatting. That fails the test of least surprises.

On that basis, I have removed the optimization to prefer thread and exception safety instead.

To compensate a little I have doubled the default buffer size at which dynamic memory would kick in on the assumption that most situations can reasonably expect to take 2k of the stack temporarily as much as 1k without likely hitting a stack overflow. If that assumption is considered unsound for all contexts that need support, the size change can be reverted independently, but it shouldn't affect the rationale to keep the rest of the change.

If the overall change produces an actual performance issue (as in unacceptable not just slower), it might be better to review the issue in the context of that app where it is unacceptable and if any further optimization would consider reverting this change to something that is unsafe again, it might be better to make that change specific to the app that is having the problem rather than doing it in a generally library like here.