### PR TITLE
Numerous performance and correctness changes to string handling. Require...

### DIFF
--- a/Include/Rocket/Core/StringBase.h
+++ b/Include/Rocket/Core/StringBase.h
@@ -51,6 +51,8 @@ public:
 	StringBase(const T* string_start, const T* string_end);
 	StringBase(size_type length, const T character);
 	StringBase(size_type max_length, const T* fmt, ...);
+	// Move construct.
+	StringBase(StringBase<T>&& other);
 
 	~StringBase();
 
@@ -174,6 +176,8 @@ public:
 
 	inline StringBase<T>& operator=(const T* assign);
 	inline StringBase<T>& operator=(const StringBase<T>& assign);
+	// Move assign.
+	inline StringBase<T>& operator=(StringBase<T>&& rhs);
 
 	inline StringBase<T> operator+(const T* append) const;
 	inline StringBase<T> operator+(const StringBase<T>& append) const;
@@ -185,8 +189,19 @@ public:
 	inline const T& operator[](size_type index) const;
 	inline T& operator[](size_type index);
 
-protected:	
+	// Offer c_str() to make the interface somewhat more consistent with std::string.
+	// c_str() better sets expectations about what it does than CString()
+	// Having a consistent name with std::string also helps with generic code.
+	inline const T* c_str() const;
 
+protected:
+	// Obtain the local buffer without casting.
+	inline T* LocalBuffer();
+	inline const T* LocalBuffer() const;
+	// Is the Small String Optimization buffer in use.
+	inline bool IsUsingLocalBuffer() const;
+
+protected:
 	T* value;
 	size_type buffer_size;
 	size_type length;
@@ -210,7 +225,7 @@ protected:
 	inline StringBase<T>& _Assign(const T* assign, size_type assign_length, size_type count = StringBase<T>::npos);
 	inline void _Insert(size_type index, const T* insert, size_type insert_length, size_type count = StringBase<T>::npos);
 };
-	
+
 #include "StringBase.inl"
 
 }

--- a/Source/Core/PropertyParserNumber.cpp
+++ b/Source/Core/PropertyParserNumber.cpp
@@ -57,6 +57,7 @@ bool PropertyParserNumber::ParseValue(Property& property, const String& value, c
 	property.unit = Property::NUMBER;
 
 	// Check for a unit declaration at the end of the number.
+	size_t suffixLength = 0;
 	for (size_t i = 0; i < unit_suffixes.size(); i++)
 	{
 		const UnitSuffix& unit_suffix = unit_suffixes[i];
@@ -66,13 +67,17 @@ bool PropertyParserNumber::ParseValue(Property& property, const String& value, c
 
 		if (strcasecmp(value.CString() + (value.Length() - unit_suffix.second.Length()), unit_suffix.second.CString()) == 0)
 		{
+			// Found a suffix, remember the size.
+			suffixLength = unit_suffix.second.Length();
 			property.unit = unit_suffix.first;
 			break;
 		}
 	}
 
 	float float_value;
-	if (sscanf(value.CString(), "%f", &float_value) == 1)
+	// Remove the unit suffix if there was one so sscanf doesn't see it and get confused.
+	int matched = sscanf(suffixLength == 0 ? value.CString() : value.Substring(0, value.Length() - suffixLength).CString(), 		"%f", &float_value);
+	if (matched == 1)
 	{
 		property.value = Variant(float_value);
 		return true;

--- a/Source/Core/String.cpp
+++ b/Source/Core/String.cpp
@@ -42,14 +42,14 @@ int ROCKETCORE_API RocketStringFormatString(StringBase<char>& string, int max_si
 	if (max_size + 1 > INTERNAL_BUFFER_SIZE)
 	{
 		std::unique_ptr<char[]> buffer_ptr(new char[max_size + 1]);
-		int length = vsnprintf(buffer_ptr.get(), max_size, format, argument_list);
+		length = vsnprintf(buffer_ptr.get(), max_size, format, argument_list);
 		buffer_ptr[length >= 0 ? length : max_size] = '\0';
 		string = buffer_ptr.get();
 	}
 	else
 	{
 		char buffer[INTERNAL_BUFFER_SIZE];
-		int length = vsnprintf(buffer, max_size, format, argument_list);
+		length = vsnprintf(buffer, max_size, format, argument_list);
 		buffer[length >= 0 ? length : max_size] = '\0';
 		string = buffer;
 	}


### PR DESCRIPTION
...s C++11.

* Formatting - change design to favour fixing thread and exception safety over performance.
* Increase performance in some situations by the provision of move constructors and move assignment functions.
* Attempt to reduce string memory reallocations for replacement and concatenation by avoiding temporaries.
* Clear hash value where required such as in Erase.
* Don't clear hash value if not required for Replace.
* Null terminate in clear as if one does Assign("X") then Clear then CString() one expects null terminated string.
* Don't use Clear in StringBase itself to favour concatenation performance, only release memory on destruction.
* Hopefully make tolower/touppwer simpler/faster and reduce memory reallocation potential and preserve hash more often.
* Add exception to replace assert for out of memory condition. Both could be used if assert is debug only.
* Some small changes to reduce the need to cast to T* so much..
* Use T() in preference to '\0' in an attempt to get proper character type for wide char types etc..
* c++11 required. I use Windows but did try g++ and cmake with -DCMAKE_CXX_FLAGS=-std=c++11 which worked.

Sorry for single commit.