### PR TITLE
Modified - Fixed samples with Win32 + OpenGL

### DIFF
--- a/Samples/basic/customlog/src/main.cpp
+++ b/Samples/basic/customlog/src/main.cpp
@@ -68,7 +68,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
 	int window_width = 1024;

--- a/Samples/basic/drag/src/main.cpp
+++ b/Samples/basic/drag/src/main.cpp
@@ -68,7 +68,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
         int window_width = 1024;

--- a/Samples/basic/loaddocument/src/main.cpp
+++ b/Samples/basic/loaddocument/src/main.cpp
@@ -67,7 +67,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
         int window_width = 1024;

--- a/Samples/basic/sfml2/src/main.cpp
+++ b/Samples/basic/sfml2/src/main.cpp
@@ -46,7 +46,7 @@
 int main(int argc, char **argv)
 {
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        //AllocConsole();
 #endif
 
         int window_width = 1024;

--- a/Samples/basic/treeview/src/main.cpp
+++ b/Samples/basic/treeview/src/main.cpp
@@ -70,7 +70,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
         int window_width = 1024;

--- a/Samples/invaders/src/main.cpp
+++ b/Samples/invaders/src/main.cpp
@@ -79,7 +79,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-	DoAllocConsole();
+	AllocConsole();
 #endif
 
 	int window_width = 1024;

--- a/Samples/shell/src/win32/ShellRenderInterfaceExtensionsOpenGL_Win32.cpp
+++ b/Samples/shell/src/win32/ShellRenderInterfaceExtensionsOpenGL_Win32.cpp
@@ -119,7 +119,7 @@ bool ShellRenderInterfaceOpenGL::AttachToNative(void *nativeWindow)
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	RECT crect;
-	GetClientRect(this->window_handle, &crect)
+	GetClientRect(this->window_handle, &crect);
 	glOrtho(0, (crect.right - crect.left), (crect.bottom - crect.top), 0, -1, 1);
 
 	glMatrixMode(GL_MODELVIEW);

--- a/Samples/tutorial/datagrid/src/main.cpp
+++ b/Samples/tutorial/datagrid/src/main.cpp
@@ -54,7 +54,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
 	ShellRenderInterfaceOpenGL opengl_renderer;

--- a/Samples/tutorial/datagrid_tree/src/main.cpp
+++ b/Samples/tutorial/datagrid_tree/src/main.cpp
@@ -55,7 +55,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
 	int window_width = 1024;

--- a/Samples/tutorial/template/src/main.cpp
+++ b/Samples/tutorial/template/src/main.cpp
@@ -51,7 +51,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
 	int window_width = 1024;

--- a/Samples/tutorial/tutorial_drag/src/main.cpp
+++ b/Samples/tutorial/tutorial_drag/src/main.cpp
@@ -52,7 +52,7 @@ int main(int ROCKET_UNUSED_PARAMETER(argc), char** ROCKET_UNUSED_PARAMETER(argv)
 #endif
 
 #ifdef ROCKET_PLATFORM_WIN32
-        DoAllocConsole();
+        AllocConsole();
 #endif
 
 	int window_width = 1024;

--- a/building_for_beginners.txt
+++ b/building_for_beginners.txt
@@ -1,0 +1,22 @@
+//Date: March 7, 2015
+
+This text file is geared towards beginner C++ programmers.
+
+This was compiled with g++ during the 1.3.0 release for libRocket for Windows 8.1, using GCC from the MinGW-w64 distribution for i686 (x86, 32-bit) architectures with POSIX threads as well as DWARF exception handling, revision 2.
+
+Assuming you'll be using MinGW-w64 (the regular MinGW compiler and even the TDM-GCC distribution, at this point, are still missing std::to_string() support by default), as well as the CMake GUI, you'll need to run the CMake GUI and then specify the "Where is the source code" box as the /libRocket/Build folder, not the source. Likewise, you may want to build your files in a separate /librocket/bin folder.
+
+You'll need to bind libRocket to a certain framework for general window handling: two viable options are SDL and SFML. After obtaining the correct DLL/LIB/A files as well as the header files either of the two, ensure that you specify the FRAMEWORK_INCLUDE_DIR as the /include directory and the FRAMEWORK_XXXX_LIBRARY_DEBUG/RELEASE as the actual .DLL file or the LIB file.
+
+Continuing, you'll find that you probably need to get GLEW. Once again, you'll need to obtain another library from the GLEW website. Once you get it, the library needs to be linked against its x86/Win32 glew32.lib file, most likely under release. The GLEW_INCLUDE_DIR should be specified as the /include directory with the header files.
+
+You may want to check off SKIP_DIRECTX_SAMPLES.
+
+At this point, the samples within libRocket are what are causing the problems; a missing semicolon here, a DoAllocConsole() to AllocConsole() there, and libRocket should eventually compile.
+
+To have the same programs run, you must place the correct DLL files into the folder of the sample in the Samples folder. Some examples also need to access the assets folder as well as their own resources folder, so make sure you place the program into the right folder.
+
+Congratulations! You now have a living, breathing, self-compiled version of libRocket!
+
+
+


### PR DESCRIPTION
Hi! I'm a new programmer so go easy on me!

**I was trying to compile libRocket recently, and I encountered some problems.** I found that many of the errors in building the samples was that the call to DoAllocConsole() is actually not valid--AllocConsole() seems to be the correct function call to use on Windows. After I changed the source files, I was able to compile libRocket under MinGW-w64 GCC 4.9.2. I included a guide on how I personally compiled libRocket on my Windows 8.1 system.

This is a relatively light change to libRocket, so I hope you'll take this small commit into consideration.