### PR TITLE
Sizing of absoultely positioned elements

### DIFF
--- a/Include/Rocket/Core/Element.h
+++ b/Include/Rocket/Core/Element.h
@@ -227,6 +227,8 @@ public:
 	/// @return The value of this property for this element.
 	float ResolveProperty(const Property *property, float base_value);
 
+	/// Returns 'top', 'bottom', 'left' and 'right' properties from element's style or local cache.
+	void GetOffsetProperties(const Property **top, const Property **bottom, const Property **left, const Property **right );
 	/// Returns 'border-width' properties from element's style or local cache.
 	void GetBorderWidthProperties(const Property **border_top_width, const Property **border_bottom_width, const Property **border_left_width, const Property **border_right_width);
 	/// Returns 'margin' properties from element's style or local cache.

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -537,6 +537,11 @@ float Element::ResolveProperty(const Property *property, float base_value)
 	return style->ResolveProperty(property, base_value);
 }
 
+void Element::GetOffsetProperties(const Property **top, const Property **bottom, const Property **left, const Property **right )
+{
+	style->GetOffsetProperties(top, bottom, left, right);
+}
+
 void Element::GetBorderWidthProperties(const Property **border_top, const Property **border_bottom, const Property **border_left, const Property **bottom_right)
 {
 	style->GetBorderWidthProperties(border_top, border_bottom, border_left, bottom_right);

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1836,7 +1836,7 @@ void Element::UpdateOffset()
 			// If the element is anchored right, then the position is set first so the element's right-most edge
 			// (including margins) will render up against the containing box's right-most content edge, and then
 			// offset by the resolved value.
-			if (right != NULL && right->unit != Property::KEYWORD)
+			else if (right != NULL && right->unit != Property::KEYWORD)
 				relative_offset_base.x = containing_block.x + parent_box.GetEdge(Box::BORDER, Box::LEFT) - (ResolveProperty(RIGHT, containing_block.x) + GetBox().GetSize(Box::BORDER).x + GetBox().GetEdge(Box::MARGIN, Box::RIGHT));
 
 			const Property *top = GetLocalProperty(TOP);

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -729,6 +729,11 @@ void ElementStyle::DirtyInheritedProperties(const PropertyNameList& properties)
 	element->OnPropertyChange(properties);
 }
 
+void ElementStyle::GetOffsetProperties(const Property **top, const Property **bottom, const Property **left, const Property **right )
+{
+	cache->GetOffsetProperties(top, bottom, left, right);
+}
+
 void ElementStyle::GetBorderWidthProperties(const Property **border_top_width, const Property **border_bottom_width, const Property **border_left_width, const Property **bottom_right_width)
 {
 	cache->GetBorderWidthProperties(border_top_width, border_bottom_width, border_left_width, bottom_right_width);

--- a/Source/Core/ElementStyle.h
+++ b/Source/Core/ElementStyle.h
@@ -143,6 +143,8 @@ public:
 	// Dirties rem properties.
 	void DirtyRemProperties();
 
+	/// Returns 'top', 'bottom', 'left' and 'right' properties from element's style or local cache.
+	void GetOffsetProperties(const Property **top, const Property **bottom, const Property **left, const Property **right );	
 	/// Returns 'border-width' properties from element's style or local cache.
 	void GetBorderWidthProperties(const Property **border_top_width, const Property **border_bottom_width, const Property **border_left_width, const Property **border_right_width);
 	/// Returns 'margin' properties from element's style or local cache.

--- a/Source/Core/ElementStyleCache.cpp
+++ b/Source/Core/ElementStyleCache.cpp
@@ -33,6 +33,7 @@ namespace Rocket {
 namespace Core {
 
 ElementStyleCache::ElementStyleCache(ElementStyle *style) : style(style), 
+	top(NULL), bottom(NULL), left(NULL), right(NULL),
 	border_top_width(NULL), border_bottom_width(NULL), border_left_width(NULL), border_right_width(NULL),
 	margin_top(NULL), margin_bottom(NULL), margin_left(NULL), margin_right(NULL),
 	padding_top(NULL), padding_bottom(NULL), padding_left(NULL), padding_right(NULL),
@@ -46,6 +47,7 @@ ElementStyleCache::ElementStyleCache(ElementStyle *style) : style(style),
 
 void ElementStyleCache::Clear()
 {
+	ClearOffset();
 	ClearBorder();
 	ClearMargin();
 	ClearPadding();
@@ -63,6 +65,11 @@ void ElementStyleCache::ClearInherited()
 	ClearTextAlign();
 	ClearTextTransform();
 	ClearVerticalAlign();
+}
+
+void ElementStyleCache::ClearOffset()
+{
+	top = bottom = left = right = NULL;
 }
 
 void ElementStyleCache::ClearBorder()
@@ -129,6 +136,37 @@ void ElementStyleCache::ClearTextTransform()
 void ElementStyleCache::ClearVerticalAlign()
 {
 	vertical_align = NULL;
+}
+
+void ElementStyleCache::GetOffsetProperties(const Property **o_top, const Property **o_bottom, const Property **o_left, const Property **o_right )
+{
+	if (o_top)
+	{
+		if (!top)
+			top = style->GetProperty(TOP);
+		*o_top = top;
+	}
+
+	if (o_bottom)
+	{
+		if (!bottom)
+			bottom = style->GetProperty(BOTTOM);
+		*o_bottom = bottom;
+	}
+
+	if (o_left)
+	{
+		if (!left)
+			left = style->GetProperty(LEFT);
+		*o_left = left;
+	}
+
+	if (o_right)
+	{
+		if (!right)
+			right = style->GetProperty(RIGHT);
+		*o_right = right;
+	}
 }
 
 void ElementStyleCache::GetBorderWidthProperties(const Property **o_border_top_width, const Property **o_border_bottom_width, const Property **o_border_left_width, const Property **o_border_right_width)

--- a/Source/Core/ElementStyleCache.h
+++ b/Source/Core/ElementStyleCache.h
@@ -55,6 +55,7 @@ public:
 	void ClearInherited();
 
 	/// Invalidation functions for individual and grouped non-inherited properties
+	void ClearOffset();
 	void ClearBorder();
 	void ClearMargin();
 	void ClearPadding();
@@ -71,6 +72,8 @@ public:
 	void ClearTextTransform();
 	void ClearVerticalAlign();
 
+	/// Returns 'top', 'bottom', 'left' and 'right' properties from element's style or local cache.
+	void GetOffsetProperties(const Property **top, const Property **bottom, const Property **left, const Property **right );
 	/// Returns 'border-width' properties from element's style or local cache.
 	void GetBorderWidthProperties(const Property **border_top_width, const Property **border_bottom_width, const Property **border_left_width, const Property **border_right_width);
 	/// Returns 'margin' properties from element's style or local cache.
@@ -107,6 +110,7 @@ private:
 	ElementStyle *style;
 
 	/// Cached properties.
+	const Property *top, *bottom, *left, *right;
 	const Property *border_top_width, *border_bottom_width, *border_left_width, *border_right_width;
 	const Property *margin_top, *margin_bottom, *margin_left, *margin_right;
 	const Property *padding_top, *padding_bottom, *padding_left, *padding_right;


### PR DESCRIPTION
Modified the implementation of the size calculations for absolutely positioned elements so that they can be resized by setting the offset properties (top, bottom, left and right).

The implementation also extends the attribute cache to include the offset properties.

### Example
Consider the following rml
```html
<rml>
	<head>
		<title>Test</title>
		<style type="text/css">
			body {
				width: 400px;
				height: 300px;
				background-color: #555;
				font-family: DejaVu Sans Mono;
				font-size: 12pt;
				color: #fff;
				margin: 0 0 0 0;
			}
			div {
				display: block;
			}			
			#a {
				position: absolute;
				background-color: #700;
				top: 0;
				right: 0;
				left: 0;
				height: 10%;
			}
			#b {
				position: absolute;
				background-color: #070;
				top: 10%;
				bottom: 50px;						
				left: 0;
				right: 15%;
			}
			#c {
				position: absolute;
				background-color: #007;
				left: 0px;
				right: 0px;
				bottom: 0px;
				height: 50px;
			}
			#d {
				position: absolute;
				background-color: #770;
				top: 10%;
				bottom: 50px;
				left: 85%;
				right: 0;
			}
		</style>		
	</head>
	<body>
		<div id="a">A</div>
		<div id="b">B</div>
		<div id="c">C</div>
		<div id="d">D</div>
	</body>
</rml>
```
Rendering this in firefox (changing the rml-tags to html) gives this result:
![firefox_absolute](https://cloud.githubusercontent.com/assets/10638395/7284326/0c5cb8c2-e93d-11e4-9dcf-01e55c343288.png)

Rendering the rml with libRocket gives this:
![rocket_absolute_before](https://cloud.githubusercontent.com/assets/10638395/7284341/2ff46d5c-e93d-11e4-81f6-5613153795ec.png)

After these changes my branch now renders the following:
![rocket_absolute_after](https://cloud.githubusercontent.com/assets/10638395/7284363/49dd365e-e93d-11e4-8898-878a70c14c5a.png)


I could not find any issue for this, but I did find that some question has been raised on the forums:
* http://forums.librocket.com/viewtopic.php?f=2&t=825&p=1971
* http://forums.librocket.com/viewtopic.php?f=2&t=5220&p=7363



