### PR TITLE
Fixed nil issue in getter of tag_name with Lua binding

### DIFF
--- a/Source/Core/Lua/Element.cpp
+++ b/Source/Core/Lua/Element.cpp
@@ -495,7 +495,7 @@ int ElementGetAttrtag_name(lua_State* L)
     Element* ele = LuaType<Element>::check(L,1);
     LUACHECKOBJ(ele);
     lua_pushstring(L,ele->GetTagName().CString());
-    return 0;
+    return 1;
 }
 
 


### PR DESCRIPTION
The return value in C tells how many values you are actually returning.