### PR TITLE
Lua 5.3 support

### DIFF
--- a/Samples/luainvaders/src/LuaInterface.cpp
+++ b/Samples/luainvaders/src/LuaInterface.cpp
@@ -84,7 +84,7 @@ int GameSetPaused(lua_State* L)
 
 int GameSetDifficulty(lua_State* L)
 {
-    int difficulty = luaL_checkint(L,1);
+    int difficulty = luaL_checkinteger(L,1);
     GameDetails::SetDifficulty((GameDetails::Difficulty)difficulty);
     return 0;
 }

--- a/Source/Controls/Lua/DataSource.cpp
+++ b/Source/Controls/Lua/DataSource.cpp
@@ -48,8 +48,8 @@ int DataSourceNotifyRowAdd(lua_State* L, DataSource* obj)
 {
     LUACHECKOBJ(obj);
     const char* table_name = luaL_checkstring(L,1);
-    int first_row_added = luaL_checkint(L,2);
-    int num_rows_added = luaL_checkint(L,3);
+    int first_row_added = luaL_checkinteger(L,2);
+    int num_rows_added = luaL_checkinteger(L,3);
     obj->NotifyRowAdd(table_name,first_row_added,num_rows_added);
     return 0;
 }
@@ -58,8 +58,8 @@ int DataSourceNotifyRowRemove(lua_State* L, DataSource* obj)
 {
     LUACHECKOBJ(obj);
     const char* table_name = luaL_checkstring(L,1);
-    int first_row_removed = luaL_checkint(L,2);
-    int num_rows_removed = luaL_checkint(L,3);
+    int first_row_removed = luaL_checkinteger(L,2);
+    int num_rows_removed = luaL_checkinteger(L,3);
     obj->NotifyRowRemove(table_name,first_row_removed,num_rows_removed);
     return 0;
 }
@@ -74,8 +74,8 @@ int DataSourceNotifyRowChange(lua_State* L, DataSource* obj)
     }
     else
     {
-        int first_row_changed = luaL_checkint(L,2);
-        int num_rows_changed = luaL_checkint(L,3);
+        int first_row_changed = luaL_checkinteger(L,2);
+        int num_rows_changed = luaL_checkinteger(L,3);
         obj->NotifyRowChange(table_name,first_row_changed,num_rows_changed);
     }
     return 0;

--- a/Source/Controls/Lua/ElementFormControlInput.cpp
+++ b/Source/Controls/Lua/ElementFormControlInput.cpp
@@ -103,7 +103,7 @@ int ElementFormControlInputSetAttrmaxlength(lua_State* L)
 {
     ElementFormControlInput* obj = LuaType<ElementFormControlInput>::check(L,1);
     LUACHECKOBJ(obj);
-    int maxlength = luaL_checkint(L,2);
+    int maxlength = luaL_checkinteger(L,2);
     obj->SetAttribute("maxlength",maxlength);
     return 0;
 }
@@ -112,7 +112,7 @@ int ElementFormControlInputSetAttrsize(lua_State* L)
 {
     ElementFormControlInput* obj = LuaType<ElementFormControlInput>::check(L,1);
     LUACHECKOBJ(obj);
-    int size = luaL_checkint(L,2);
+    int size = luaL_checkinteger(L,2);
     obj->SetAttribute("size",size);
     return 0;
 }
@@ -121,7 +121,7 @@ int ElementFormControlInputSetAttrmax(lua_State* L)
 {
     ElementFormControlInput* obj = LuaType<ElementFormControlInput>::check(L,1);
     LUACHECKOBJ(obj);
-    int max = luaL_checkint(L,2);
+    int max = luaL_checkinteger(L,2);
     obj->SetAttribute("max",max);
     return 0;
 }
@@ -130,7 +130,7 @@ int ElementFormControlInputSetAttrmin(lua_State* L)
 {
     ElementFormControlInput* obj = LuaType<ElementFormControlInput>::check(L,1);
     LUACHECKOBJ(obj);
-    int min = luaL_checkint(L,2);
+    int min = luaL_checkinteger(L,2);
     obj->SetAttribute("min",min);
     return 0;
 }
@@ -139,7 +139,7 @@ int ElementFormControlInputSetAttrstep(lua_State* L)
 {
     ElementFormControlInput* obj = LuaType<ElementFormControlInput>::check(L,1);
     LUACHECKOBJ(obj);
-    int step = luaL_checkint(L,2);
+    int step = luaL_checkinteger(L,2);
     obj->SetAttribute("step",step);
     return 0;
 }

--- a/Source/Controls/Lua/ElementFormControlSelect.cpp
+++ b/Source/Controls/Lua/ElementFormControlSelect.cpp
@@ -46,7 +46,7 @@ int ElementFormControlSelectAdd(lua_State* L, ElementFormControlSelect* obj)
     const char* value = luaL_checkstring(L,2);
     int before = -1; //default
     if(lua_gettop(L) >= 3)
-        before = luaL_checkint(L,3);
+        before = luaL_checkinteger(L,3);
 
     int index = obj->Add(rml,value,before);
     lua_pushinteger(L,index);
@@ -55,7 +55,7 @@ int ElementFormControlSelectAdd(lua_State* L, ElementFormControlSelect* obj)
 
 int ElementFormControlSelectRemove(lua_State* L, ElementFormControlSelect* obj)
 {
-    int index = luaL_checkint(L,1);
+    int index = luaL_checkinteger(L,1);
     obj->Remove(index);
     return 0;
 }
@@ -86,7 +86,7 @@ int ElementFormControlSelectSetAttrselection(lua_State* L)
 {
     ElementFormControlSelect* obj = LuaType<ElementFormControlSelect>::check(L,1);
     LUACHECKOBJ(obj);
-    int selection = luaL_checkint(L,2);
+    int selection = luaL_checkinteger(L,2);
     obj->SetSelection(selection);
     return 0;
 }

--- a/Source/Controls/Lua/ElementFormControlTextArea.cpp
+++ b/Source/Controls/Lua/ElementFormControlTextArea.cpp
@@ -74,7 +74,7 @@ int ElementFormControlTextAreaSetAttrcols(lua_State* L)
 {
     ElementFormControlTextArea* obj = LuaType<ElementFormControlTextArea>::check(L,1);
     LUACHECKOBJ(obj);
-    int cols = luaL_checkint(L,2);
+    int cols = luaL_checkinteger(L,2);
     obj->SetNumColumns(cols);
     return 0;
 }
@@ -83,7 +83,7 @@ int ElementFormControlTextAreaSetAttrmaxlength(lua_State* L)
 {
     ElementFormControlTextArea* obj = LuaType<ElementFormControlTextArea>::check(L,1);
     LUACHECKOBJ(obj);
-    int ml = luaL_checkint(L,2);
+    int ml = luaL_checkinteger(L,2);
     obj->SetMaxLength(ml);
     return 0;
 }
@@ -92,7 +92,7 @@ int ElementFormControlTextAreaSetAttrrows(lua_State* L)
 {
     ElementFormControlTextArea* obj = LuaType<ElementFormControlTextArea>::check(L,1);
     LUACHECKOBJ(obj);
-    int rows = luaL_checkint(L,2);
+    int rows = luaL_checkinteger(L,2);
     obj->SetNumRows(rows);
     return 0;
 }

--- a/Source/Controls/Lua/ElementTabSet.cpp
+++ b/Source/Controls/Lua/ElementTabSet.cpp
@@ -39,7 +39,7 @@ namespace Lua {
 int ElementTabSetSetPanel(lua_State* L, ElementTabSet* obj)
 {
     LUACHECKOBJ(obj);
-    int index = luaL_checkint(L,1);
+    int index = luaL_checkinteger(L,1);
     const char* rml = luaL_checkstring(L,2);
 
     obj->SetPanel(index,rml);
@@ -49,7 +49,7 @@ int ElementTabSetSetPanel(lua_State* L, ElementTabSet* obj)
 int ElementTabSetSetTab(lua_State* L, ElementTabSet* obj)
 {
     LUACHECKOBJ(obj);
-    int index = luaL_checkint(L,1);
+    int index = luaL_checkinteger(L,1);
     const char* rml = luaL_checkstring(L,2);
 
     obj->SetTab(index,rml);
@@ -82,7 +82,7 @@ int ElementTabSetSetAttractive_tab(lua_State* L)
 {
     ElementTabSet* obj = LuaType<ElementTabSet>::check(L,1);
     LUACHECKOBJ(obj);
-    int tab = luaL_checkint(L,2);
+    int tab = luaL_checkinteger(L,2);
     obj->SetActiveTab(tab);
     return 0;
 }

--- a/Source/Controls/Lua/LuaDataSource.cpp
+++ b/Source/Controls/Lua/LuaDataSource.cpp
@@ -98,7 +98,7 @@ int LuaDataSource::GetNumRows(const Rocket::Core::String& table)
     int res = lua_gettop(L);
     if(lua_type(L,res) == LUA_TNUMBER)
     {
-        return luaL_checkint(L,res);
+        return luaL_checkinteger(L,res);
     }
     else
     {

--- a/Source/Controls/Lua/SelectOptionsProxy.cpp
+++ b/Source/Controls/Lua/SelectOptionsProxy.cpp
@@ -43,7 +43,7 @@ int SelectOptionsProxy__index(lua_State* L)
     {
         SelectOptionsProxy* proxy = LuaType<SelectOptionsProxy>::check(L,1);
         LUACHECKOBJ(proxy);
-        int index = luaL_checkint(L,2);
+        int index = luaL_checkinteger(L,2);
         Rocket::Controls::SelectOption* opt = proxy->owner->GetOption(index);
         LUACHECKOBJ(opt);
         lua_newtable(L);

--- a/Source/Core/Lua/Colourb.cpp
+++ b/Source/Core/Lua/Colourb.cpp
@@ -51,10 +51,10 @@ template<> void ExtraInit<Colourb>(lua_State* L, int metatable_index)
 }
 int Colourbnew(lua_State* L)
 {
-    byte red = (byte)luaL_checkint(L,1);
-    byte green = (byte)luaL_checkint(L,2);
-    byte blue = (byte)luaL_checkint(L,3);
-    byte alpha = (byte)luaL_checkint(L,4);
+    byte red = (byte)luaL_checkinteger(L,1);
+    byte green = (byte)luaL_checkinteger(L,2);
+    byte blue = (byte)luaL_checkinteger(L,3);
+    byte alpha = (byte)luaL_checkinteger(L,4);
 
     Colourb* col = new Colourb(red,green,blue,alpha);
 
@@ -196,12 +196,12 @@ int ColourbSetAttrrgba(lua_State* L)
             if(top > 2)
             {
                 if(top > 3)
-                    obj->alpha = luaL_checkint(L,4);
-                obj->blue = luaL_checkint(L,3);
+                    obj->alpha = luaL_checkinteger(L,4);
+                obj->blue = luaL_checkinteger(L,3);
             }
-            obj->green = luaL_checkint(L,2);
+            obj->green = luaL_checkinteger(L,2);
         }
-        obj->red = luaL_checkint(L,1);
+        obj->red = luaL_checkinteger(L,1);
     }
     return 0;
 }

--- a/Source/Core/Lua/ContextDocumentsProxy.cpp
+++ b/Source/Core/Lua/ContextDocumentsProxy.cpp
@@ -54,7 +54,7 @@ int ContextDocumentsProxy__index(lua_State* L)
         if(type == LUA_TSTRING)
             ret = proxy->owner->GetDocument(luaL_checkstring(L,2));
         else
-            ret = proxy->owner->GetDocument(luaL_checkint(L,2));
+            ret = proxy->owner->GetDocument(luaL_checkinteger(L,2));
         LuaType<Document>::push(L,ret,false);
         return 1;
     }

--- a/Source/Core/Lua/ElementChildNodesProxy.cpp
+++ b/Source/Core/Lua/ElementChildNodesProxy.cpp
@@ -51,7 +51,7 @@ int ElementChildNodesProxy__index(lua_State* L)
     {
         ElementChildNodesProxy* obj = LuaType<ElementChildNodesProxy>::check(L,1);
         LUACHECKOBJ(obj);
-        int key = luaL_checkint(L,2);
+        int key = luaL_checkinteger(L,2);
         Element* child = obj->owner->GetChild(key);
         LuaType<Element>::push(L,child,false);
         return 1;

--- a/Source/Core/Lua/GlobalLuaFunctions.cpp
+++ b/Source/Core/Lua/GlobalLuaFunctions.cpp
@@ -72,7 +72,7 @@ int rocket_pairs(lua_State* L)
 
 //copy + pasted from Lua's lbaselib.c
 int ipairsaux (lua_State *L) {
-    int i = luaL_checkint(L, 2);
+    int i = luaL_checkinteger(L, 2);
     luaL_checktype(L, 1, LUA_TTABLE);
     i++;  /* next value */
     lua_pushinteger(L, i);

--- a/Source/Core/Lua/RocketContextsProxy.cpp
+++ b/Source/Core/Lua/RocketContextsProxy.cpp
@@ -60,7 +60,7 @@ int RocketContextsProxy__index(lua_State* L)
         }
         else
         {
-            int key = luaL_checkint(L,2);
+            int key = luaL_checkinteger(L,2);
             LuaType<Context>::push(L,GetContext(key));
         }
         return 1;

--- a/Source/Core/Lua/Vector2i.cpp
+++ b/Source/Core/Lua/Vector2i.cpp
@@ -58,8 +58,8 @@ template<> void ExtraInit<Vector2i>(lua_State* L, int metatable_index)
 
 int Vector2inew(lua_State* L)
 {
-    int x = luaL_checkint(L,1);
-    int y = luaL_checkint(L,2);
+    int x = luaL_checkinteger(L,1);
+    int y = luaL_checkinteger(L,2);
 
     Vector2i* vect = new Vector2i(x,y);
 
@@ -71,7 +71,7 @@ int Vector2i__mul(lua_State* L)
 {
     Vector2i* lhs = LuaType<Vector2i>::check(L,1);
     LUACHECKOBJ(lhs);
-    int rhs = luaL_checkint(L,2);
+    int rhs = luaL_checkinteger(L,2);
 
     Vector2i* res = new Vector2i(0,0);
     (*res) = (*lhs) * rhs;
@@ -84,7 +84,7 @@ int Vector2i__div(lua_State* L)
 {
     Vector2i* lhs = LuaType<Vector2i>::check(L,1);
     LUACHECKOBJ(lhs);
-    int rhs = luaL_checkint(L,2);
+    int rhs = luaL_checkinteger(L,2);
 
     Vector2i* res = new Vector2i(0,0);
     (*res) = (*lhs) / rhs;
@@ -163,7 +163,7 @@ int Vector2iSetAttrx(lua_State*L)
 {
     Vector2i* self = LuaType<Vector2i>::check(L,1);
     LUACHECKOBJ(self);
-    int value = luaL_checkint(L,2);
+    int value = luaL_checkinteger(L,2);
 
     self->x = value;
     return 0;
@@ -173,7 +173,7 @@ int Vector2iSetAttry(lua_State*L)
 {
     Vector2i* self = LuaType<Vector2i>::check(L,1);
     LUACHECKOBJ(self);
-    int value = luaL_checkint(L,2);
+    int value = luaL_checkinteger(L,2);
 
     self->y = value;
     return 0;


### PR DESCRIPTION
`luaL_checkint` was deprecated in Lua 5.3: [Details](http://www.lua.org/manual/5.3/manual.html#8.3)
Discussion about casting: [Should we explicitly cast from luaL_checkinteger() et al?](http://lua-users.org/lists/lua-l/2015-01/msg00614.html)
