### PR TITLE
generate libRocketConfig.cmake files

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -277,10 +277,13 @@ foreach(library ${LIBRARIES})
     )
     
     install(TARGETS ${NAME}
+            EXPORT libRocketTargets
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
+
+    set(ROCKET_EXPORTED_TARGETS ${ROCKET_EXPORTED_TARGETS} ${NAME})
 endforeach(library)
 else(NOT BUILD_FRAMEWORK)
 	#===================================
@@ -338,11 +341,14 @@ else(NOT BUILD_FRAMEWORK)
 		)
 
     install(TARGETS ${NAME}
+            EXPORT libRocketTargets
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             FRAMEWORK DESTINATION Library/Frameworks
     )
+
+    set(ROCKET_EXPORTED_TARGETS ${ROCKET_EXPORTED_TARGETS} ${NAME})
 endif(NOT BUILD_FRAMEWORK)
 
 # Build python bindings
@@ -360,8 +366,10 @@ if(BUILD_PYTHON_BINDINGS)
         set_target_properties(${NAME} PROPERTIES PREFIX "")
 
         install(TARGETS ${NAME}
+                EXPORT libRocketTargets
                 LIBRARY DESTINATION ${PYTHON_INSTDIR}
         )
+ 
     endforeach(library)
 endif()
 
@@ -383,10 +391,13 @@ if(BUILD_LUA_BINDINGS)
         )
         
         install(TARGETS ${NAME}
+            EXPORT libRocketTargets
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         )
+        
+        set(ROCKET_EXPORTED_TARGETS ${ROCKET_EXPORTED_TARGETS} ${NAME})
     endforeach(library)
 endif()
 
@@ -799,4 +810,51 @@ if(BUILD_SAMPLES)
                 DESTINATION ${SAMPLES_DIR}/luainvaders
         )
     endif()
+endif()
+
+#===================================
+# Generate Config.cmake files ======
+#===================================
+
+# Try to include helper module
+include(CMakePackageConfigHelpers OPTIONAL
+  RESULT_VARIABLE PkgHelpers_AVAILABLE)
+# guard against older versions of cmake which do not provide it
+if(PkgHelpers_AVAILABLE)
+
+  set (INCLUDE_INSTALL_DIR "include")
+  set (LIB_INSTALL_DIR "lib")
+  set (INCLUDE_DIR "${PROJECT_SOURCE_DIR}/Include")
+
+  # generate configuration for install tree
+  configure_package_config_file(libRocketConfig.cmake.install.in
+    ${CMAKE_CURRENT_BINARY_DIR}/install/libRocketConfig.cmake
+    INSTALL_DESTINATION ${LIB_INSTALL_DIR}/libRocket/cmake
+    PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/install/libRocketConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion )
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/libRocketConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/install/libRocketConfigVersion.cmake
+    DESTINATION ${LIB_INSTALL_DIR}/libRocket/cmake )
+  install(EXPORT libRocketTargets
+    DESTINATION ${LIB_INSTALL_DIR}/libRocket/cmake)
+
+  # generate configuration for build tree
+  configure_package_config_file(libRocketConfig.cmake.build.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libRocketConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR)
+  export(TARGETS ${ROCKET_EXPORTED_TARGETS}
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/libRocketTargets.cmake")
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/libRocketConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion )
+  set(libRocket_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "The directory containing a CMake configuration file for libRocket.")
+else()
+  message("If you wish to use find_package(libRocket) in your own project to find libRocket library"
+    " please update cmake to version which provides CMakePackageConfighelpers module"
+    " or write generators for libRocketConfig.cmake by yourself.")
 endif()

--- a/Build/libRocketConfig.cmake.build.in
+++ b/Build/libRocketConfig.cmake.build.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+set_and_check(libRocket_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
+set(libRocket_LIBRARIES @ROCKET_EXPORTED_TARGETS@)
+list(GET libRocket_LIBRARIES 0 ROCKET_FIRST_TARGET)
+
+if(NOT (TARGET ${ROCKET_FIRST_TARGET}))
+  include("${CMAKE_CURRENT_LIST_DIR}/libRocketTargets.cmake")
+endif()
+
+check_required_components(libRocket)

--- a/Build/libRocketConfig.cmake.install.in
+++ b/Build/libRocketConfig.cmake.install.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+set_and_check(libRocket_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set(libRocket_LIBRARIES @ROCKET_EXPORTED_TARGETS@)
+include("${CMAKE_CURRENT_LIST_DIR}/libRocketTargets.cmake")
+
+check_required_components(libRocket)


### PR DESCRIPTION
Generate appropriate `libRocketConfig.cmake` files so `find_package` works properly.

After installing libRocket (using cmake) under one of the predefined default locations other projects may find it by calling `find_package(libRocket)`. After successful call variable `libRocket_INCLUDE_DIRS` should be initialized with path to libRocket headers and `libRocket_LIBRARIES` variable should be initialized with appropriate targets to link with, e.g.
```
find_package(libRocket REQUIRED NO_CMAKE_PATH)
include_directories(${libRocket_INCLUDE_DIRS})
# ...
target_link_libraries(my_app ${libRocket_LIBRARIES})
```
If you wish to use libRocket installed under non-standard location use `libRocket_DIR` variable to point out directory with appropriate `libRocketConfig.cmake file`. It is usually installed under `<install_prefix>/lib/libRocket/cmake` path, e.g.
```
set(CppUTest_DIR "/opt/weird_path/lib/libRocket/cmake")
find_package(libRocket  REQUIRED NO_CMAKE_PATH)
include_directories(${libRocket_INCLUDE_DIRS})
# ...
target_link_libraries(my_app ${libRocket_LIBRARIES})
```
You may also use libRocket without installation. Just point out `libRocket_DIR` variable to the directory where libRocket was built (it's `CMAKE_BINARY_DIR`) before calling `find_package`.

Last option is to build libRocket together with your project. Put libRocket source code under subdirectory of your own project (e.g. using `git submodule`) and add that directory to build using `add_subdirectory` command. You may set libRocket configuration variables before that, e.g.
```
set(BUILD_LUA_BINDINGS ON)
add_subdirectory(ext/libRocket)
find_package(libRocket  REQUIRED NO_CMAKE_PATH)
include_directories(${libRocket_INCLUDE_DIRS})
# ...
target_link_libraries(my_app ${libRocket_LIBRARIES})
```
