### PR TITLE
Add a std::initializer_list ctor to Dictionary.

### DIFF
--- a/Include/Rocket/Core/Dictionary.h
+++ b/Include/Rocket/Core/Dictionary.h
@@ -30,6 +30,7 @@
 
 #include "Header.h"
 #include "Variant.h"
+#include <initializer_list>
 
 namespace Rocket {
 namespace Core {
@@ -46,6 +47,7 @@ class ROCKETCORE_API Dictionary
 public:
 	Dictionary();
 	Dictionary(const Dictionary &dict);
+	Dictionary(std::initializer_list<std::pair<String, Variant>> init);
 	~Dictionary();
 
 	/// Store an item in the dictionary

--- a/Source/Core/Dictionary.cpp
+++ b/Source/Core/Dictionary.cpp
@@ -185,6 +185,12 @@ Dictionary::Dictionary(const Dictionary &dict)
 	Copy(dict);
 }
 
+Dictionary::Dictionary(std::initializer_list<std::pair<String, Variant>> init) : Dictionary() {
+	Reserve(init.size());
+	for (auto& kv : init)
+		Set(kv.first, kv.second);
+}
+
 Dictionary::~Dictionary() 
 {
 	Clear();


### PR DESCRIPTION
Example usage:
Factory::InstanceElement(nullptr, "input", "input", {{"type", "text"}, {"id", "name"}});