### PR TITLE
Fixes edge-case when quitting caused access-violation

### DIFF
--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -315,6 +315,17 @@ void Context::UnloadDocument(ElementDocument* _document)
 		active = NULL;
 	}
 
+   // Clear other pointers to elements whose owner was deleted
+   if (drag && drag->GetOwnerDocument() == document)
+   {
+      drag = NULL;
+   }
+
+   if (drag_hover && drag_hover->GetOwnerDocument() == document)
+   {
+      drag_hover = NULL;
+   }
+
 	// Rebuild the hover state.
 	UpdateHoverChain(Dictionary(), Dictionary(), mouse_position);
 }
@@ -330,6 +341,16 @@ void Context::UnloadAllDocuments()
 	// before we exit this method.
 	root->active_children.clear();
 	root->ReleaseElements(root->deleted_children);
+
+   // Also need to clear containers that keep ElementReference pointers to elements belonging to removed documents,
+   // essentially preventing them from being released in correct order (before context destroys render interface,
+   // which causes access violation for elements that try to release geometry after context is released)
+   // I don't bother checking what's in chain because we unload all documents, so there shouldn't be any element
+   // that remains here (could check for element->owner == NULL, but that's probably guaranteed)
+   active_chain.clear();
+   hover_chain.clear();
+   drag_hover_chain.clear();
+
 }
 
 // Adds a previously-loaded cursor document as a mouse cursor within this context.


### PR DESCRIPTION
This really is an edge case because you have to basically click some button in UI and _instantly_ quit application (for example ESC if it support instant quit & clean-up upon receiving this key-down). I discovered it by accident, when I did exactly that - clicked element and hit ESC button, and my app just crashed. I started investigating this, and it turned out it crashes on line:

`GetRenderInterface()->ReleaseCompiledGeometry(compiled_geometry);`

After inspecing call stack it was obvious that when application is in the middle of some "drag" or other event and it has to quit, Context is destroyed without properly releasing some of its members, that are ElementReferences, so they keep some elements alive. This caused these elements to outlive Context (and so render interface), only to be destroyed after ~Context() call. At this point there was no render interface, hence the crash. 

```
Context::~Context()
{
    ...
    if (render_interface)
	render_interface->RemoveReference();
}
# here Context stack is cleared and so are members like hover_chain, active_chain, 
# all of them ElementReferences that kept these Elements alive and since we just 
# removed render_interface, it crashes there when Element tries to destroy itself
```
This needs checking by someone knowing internals, but from what I see Context has a lot of members that are capable of keeping elements alive, and they were not cleared properly. The only reason why it didn't crash every time is because these members keep track of things that happen quickly and go away, so 99% of the time these members were NULL.
