### PR TITLE
Opacity property, image colour, restrict ElementHandle moving area.

### DIFF
--- a/Source/Core/DecoratorTiled.cpp
+++ b/Source/Core/DecoratorTiled.cpp
@@ -25,6 +25,9 @@
  *
  */
 
+// Modified by uniquejack
+// Implement opacity (Check https://github.com/libRocket/libRocket/pull/262)
+
 #include "precompiled.h"
 #include "DecoratorTiled.h"
 #include "../../Include/Rocket/Core.h"
@@ -108,10 +111,21 @@ Vector2f DecoratorTiled::Tile::GetDimensions(Element* element)
 void DecoratorTiled::Tile::GenerateGeometry(std::vector< Vertex >& vertices, std::vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions) const
 {
 	RenderInterface* render_interface = element->GetRenderInterface();
-	const Property* element_colour = element->GetProperty(COLOR);
-	Colourb quad_colour = Colourb(255, 255, 255);
-	if (element_colour)
-		quad_colour = element_colour->Get<Colourb>();
+	const Property* element_colour = element->GetProperty(BACKGROUND_COLOR);
+    float opacity = element->GetProperty<float>(OPACITY);
+
+    Colourb quad_colour = Colourb(255, 255, 255);
+    if (element_colour)
+    {
+        Colourb background_colour = element_colour->Get<Colourb>();
+
+        // Should be a non-transparent background
+        if (background_colour.alpha != 0)
+            quad_colour = background_colour;
+    }
+
+    // Apply opacity
+    quad_colour.alpha = (byte)(opacity * (float)quad_colour.alpha);
 	
 	TileDataMap::iterator data_iterator = data.find(render_interface);
 	if (data_iterator == data.end())

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -25,6 +25,9 @@
  *
  */
 
+// Modified by uniquejack
+// Implement opacity (Check https://github.com/libRocket/libRocket/pull/262)
+  
 #include "precompiled.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Dictionary.h"
@@ -52,7 +55,7 @@ namespace Core {
 class ElementSortZOrder
 {
 public:
-	bool operator()(const std::pair< Element*, float >& lhs, const std::pair< Element*, float >& rhs)
+	bool operator()(const std::pair< Element*, float >& lhs, const std::pair< Element*, float >& rhs) const // uniquejack add const
 	{
 		return lhs.second < rhs.second;
 	}
@@ -65,7 +68,7 @@ public:
 class ElementSortZIndex
 {
 public:
-	bool operator()(const Element* lhs, const Element* rhs)
+	bool operator()(const Element* lhs, const Element* rhs) const // uniquejack add const
 	{
 		// Check the z-index.
 		return lhs->GetZIndex() < rhs->GetZIndex();
@@ -1563,9 +1566,12 @@ void Element::OnPropertyChange(const PropertyNameList& changed_properties)
 	}
 
 	// Dirty the background if it's changed.
-	if (all_dirty ||
-		changed_properties.find(BACKGROUND_COLOR) != changed_properties.end())
-		background->DirtyBackground();
+    if (all_dirty ||
+        changed_properties.find(BACKGROUND_COLOR) != changed_properties.end() ||
+        changed_properties.find(OPACITY) != changed_properties.end()) {
+        background->DirtyBackground();
+        decoration->ReloadDecorators();
+    }
 
 	// Dirty the border if it's changed.
 	if (all_dirty || 
@@ -1576,7 +1582,8 @@ void Element::OnPropertyChange(const PropertyNameList& changed_properties)
 		changed_properties.find(BORDER_TOP_COLOR) != changed_properties.end() ||
 		changed_properties.find(BORDER_RIGHT_COLOR) != changed_properties.end() ||
 		changed_properties.find(BORDER_BOTTOM_COLOR) != changed_properties.end() ||
-		changed_properties.find(BORDER_LEFT_COLOR) != changed_properties.end())
+		changed_properties.find(BORDER_LEFT_COLOR) != changed_properties.end() ||
+		changed_properties.find(OPACITY) != changed_properties.end())
 		border->DirtyBorder();
 
 	// Fetch a new font face if it has been changed.

--- a/Source/Core/ElementBackground.cpp
+++ b/Source/Core/ElementBackground.cpp
@@ -25,6 +25,9 @@
  *
  */
 
+// Modified by uniquejack
+// Implement opacity (Check https://github.com/libRocket/libRocket/pull/262)
+
 #include "precompiled.h"
 #include "ElementBackground.h"
 #include "../../Include/Rocket/Core/Element.h"
@@ -67,6 +70,11 @@ void ElementBackground::GenerateBackground()
 {
 	// Fetch the new colour for the background. If the colour is transparent, then we don't render any background.
 	Colourb colour = element->GetProperty(BACKGROUND_COLOR)->value.Get< Colourb >();
+	float opacity = element->GetProperty<float>(OPACITY);
+
+	// Apply opacity
+	colour.alpha = (byte)(opacity * (float)colour.alpha);
+
 	if (colour.alpha <= 0)
 	{
 		geometry.GetVertices().clear();

--- a/Source/Core/ElementBorder.cpp
+++ b/Source/Core/ElementBorder.cpp
@@ -25,6 +25,9 @@
  *
  */
 
+// Modified by uniquejack
+// Implement opacity (Check https://github.com/libRocket/libRocket/pull/262)
+ 
 #include "precompiled.h"
 #include "ElementBorder.h"
 #include "../../Include/Rocket/Core/Element.h"
@@ -93,6 +96,12 @@ void ElementBorder::GenerateBorder()
 		border_colours[1] = element->GetProperty(BORDER_RIGHT_COLOR)->value.Get< Colourb >();
 		border_colours[2] = element->GetProperty(BORDER_BOTTOM_COLOR)->value.Get< Colourb >();
 		border_colours[3] = element->GetProperty(BORDER_LEFT_COLOR)->value.Get< Colourb >();
+
+		// Apply opacity to the border
+		float opacity = element->GetProperty<float>(OPACITY);
+		for(int i = 0; i < 4; ++i) {
+			border_colours[i].alpha = (byte)(opacity * (float)border_colours[i].alpha);
+		}
 
 		for (int i = 0; i < element->GetNumBoxes(); ++i)
 			GenerateBorder(raw_vertices, raw_indices, index_offset, element->GetBox(i), border_colours);

--- a/Source/Core/ElementHandle.h
+++ b/Source/Core/ElementHandle.h
@@ -25,6 +25,8 @@
  *
  */
 
+// Modified by uniquejack
+
 #ifndef ROCKETCOREELEMENTHANDLE_H
 #define ROCKETCOREELEMENTHANDLE_H
 
@@ -58,6 +60,7 @@ protected:
 
 	Element* move_target;
 	Element* size_target;
+	Element* move_clip;
 
 	bool initialised;
 };

--- a/Source/Core/ElementImage.h
+++ b/Source/Core/ElementImage.h
@@ -25,6 +25,8 @@
  *
  */
 
+// Modified by uniquejack
+
 #ifndef ROCKETCOREELEMENTIMAGE_H
 #define ROCKETCOREELEMENTIMAGE_H
 
@@ -83,6 +85,10 @@ protected:
 	/// Checks for changes to the image's source or dimensions.
 	/// @param[in] changed_attributes A list of attributes changed on the element.
 	virtual void OnAttributeChange(const AttributeNameList& changed_attributes);
+
+	/// Called when properties on the element are changed.
+	/// @param[in] changed_properties The properties changed on the element.
+	virtual void OnPropertyChange(const PropertyNameList& changed_properties);
 
 	/// Regenerates the element's geometry on a resize event.
 	/// @param[in] event The event to process.

--- a/Source/Core/StringCache.cpp
+++ b/Source/Core/StringCache.cpp
@@ -25,6 +25,9 @@
  *
  */
 
+// Modified by uniquejack
+// Implement opacity (Check https://github.com/libRocket/libRocket/pull/262)
+ 
 #include "precompiled.h"
 
 namespace Rocket {
@@ -93,6 +96,7 @@ const String DRAG = "drag";
 const String TAB_INDEX = "tab-index";
 const String SCROLLBAR_MARGIN = "scrollbar-margin";
 const String SCROLL_DEFAULT_STEP_SIZE = "scroll-default-step-size";
+const String OPACITY = "opacity";
 
 const String MOUSEDOWN = "mousedown";
 const String MOUSESCROLL = "mousescroll";

--- a/Source/Core/StringCache.h
+++ b/Source/Core/StringCache.h
@@ -25,6 +25,9 @@
  *
  */
 
+// Modified by uniquejack
+// Implement opacity (Check https://github.com/libRocket/libRocket/pull/262)
+ 
 #ifndef ROCKETCORESTRINGCACHE_H
 #define ROCKETCORESTRINGCACHE_H
 
@@ -96,6 +99,7 @@ extern const String DRAG;
 extern const String TAB_INDEX;
 extern const String SCROLLBAR_MARGIN;
 extern const String SCROLL_DEFAULT_STEP_SIZE;
+extern const String OPACITY;
 
 extern const String MOUSEDOWN;
 extern const String MOUSESCROLL;

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -25,6 +25,9 @@
  *
  */
 
+// Modified by uniquejack
+// Implement opacity (Check https://github.com/libRocket/libRocket/pull/262)
+ 
 #include "precompiled.h"
 #include "../../Include/Rocket/Core/StyleSheetSpecification.h"
 #include "PropertyParserNumber.h"
@@ -261,6 +264,7 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(FOCUS, "auto", true, false).AddParser("keyword", "none, auto");
 
 	RegisterProperty(SCROLLBAR_MARGIN, "0", false, false).AddParser("number");
+	RegisterProperty(OPACITY, "1", true, false).AddParser("number");
 }
 
 }


### PR DESCRIPTION
These are two commits that I think should be merged. The first one lets you change the image colours and add the opacity property which I took from another pull request (just changed a few lines to make them work toghether). The second one clips the moving area of an ElementHandle e.g. a dialog window moving inside a transparent container which has the same sizes of the body. Let me know what you think.