### PR TITLE
Add missing semicolon

### DIFF
--- a/Samples/shell/src/win32/ShellRenderInterfaceExtensionsOpenGL_Win32.cpp
+++ b/Samples/shell/src/win32/ShellRenderInterfaceExtensionsOpenGL_Win32.cpp
@@ -119,7 +119,7 @@ bool ShellRenderInterfaceOpenGL::AttachToNative(void *nativeWindow)
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	RECT crect;
-	GetClientRect(this->window_handle, &crect)
+	GetClientRect(this->window_handle, &crect);
 	glOrtho(0, (crect.right - crect.left), (crect.bottom - crect.top), 0, -1, 1);
 
 	glMatrixMode(GL_MODELVIEW);


### PR DESCRIPTION
There seems to be a missing semicolon in this example. 

