### PR TITLE
Handle rem units in ElementUtilities::GetLineHeight

### DIFF
--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -136,13 +136,18 @@ int ElementUtilities::GetFontSize(Element* element)
 // Returns an element's line height, if it has a font defined.
 int ElementUtilities::GetLineHeight(Element* element)
 {
-	FontFaceHandle* font_face_handle = element->GetFontFaceHandle();
+	const Property* line_height_property = element->GetLineHeightProperty();
+
+	Element* font_element = element;
+	if (line_height_property->unit == Property::REM)
+		font_element = element->GetOwnerDocument();
+
+	FontFaceHandle* font_face_handle = font_element->GetFontFaceHandle();
 	if (font_face_handle == NULL)
 		return 0;
 
 	int line_height = font_face_handle->GetLineHeight();
 	float inch = element->GetRenderInterface()->GetPixelsPerInch();
-	const Property* line_height_property = element->GetLineHeightProperty();
 
 	switch (line_height_property->unit)
 	{
@@ -155,6 +160,7 @@ int ElementUtilities::GetLineHeight(Element* element)
 	ROCKET_UNUSED_SWITCH_ENUM(Property::RELATIVE_UNIT);
 	case Property::NUMBER:
 	case Property::EM:
+	case Property::REM:
 		// If the property is a straight number or an em measurement, then it scales the line height.
 		return Math::Round(line_height_property->value.Get< float >() * line_height);
 	case Property::PERCENT:


### PR DESCRIPTION
Not handling the Property::REM enumeration value gives build warnings with -Wswitch on Clang. This pull request fixes the warning by making rem line height work as designed, by using the font of the document's root.

(Or does it make no sense to use the whole document's font for line height and it's better to handle it like em or to return 0?)
