### PR TITLE
Add visual disambiguation parentheses to ElementTextDefault::GenerateLine

### DIFF
--- a/Source/Core/ElementTextDefault.cpp
+++ b/Source/Core/ElementTextDefault.cpp
@@ -216,7 +216,7 @@ bool ElementTextDefault::GenerateLine(WString& line, int& line_length, float& li
 		{
 			if (!line.Empty() &&
 				(line_width + token_width > maximum_line_width ||
-				 LastToken(next_token_begin, string_end, collapse_white_space, break_at_endline) && line_width + token_width > maximum_line_width - right_spacing_width))
+				 (LastToken(next_token_begin, string_end, collapse_white_space, break_at_endline) && line_width + token_width > maximum_line_width - right_spacing_width)))
 			{
 				return false;
 			}


### PR DESCRIPTION
Fixes a -Wlogical-op-parentheses build warning.