### PR TITLE
Add example to use libRocket with SDL2 SDL_Renderer / SDL_RenderGeometry()

### DIFF
--- a/Samples/basic/sdl2_sdlrenderer/src/RenderInterfaceSDL2.cpp
+++ b/Samples/basic/sdl2_sdlrenderer/src/RenderInterfaceSDL2.cpp
@@ -1,0 +1,178 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 Nuno Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <Rocket/Core/Core.h>
+#include <SDL_image.h>
+
+#include "RenderInterfaceSDL2.h"
+
+#include <cstddef>
+
+#if !(SDL_VIDEO_RENDER_OGL)
+    #error "Only the opengl sdl backend is supported. To add support for others, see http://mdqinc.com/blog/2013/01/integrating-librocket-with-sdl-2/"
+#endif
+
+RocketSDL2Renderer::RocketSDL2Renderer(SDL_Renderer* renderer, SDL_Window* screen)
+{
+    mRenderer = renderer;
+    mScreen = screen;
+
+    SDL_GetRendererOutputSize(renderer, &mRenderer_w, &mRenderer_h);
+
+    mRectScisor.x = 0;
+    mRectScisor.y = 0;
+    mRectScisor.w = mRenderer_w;
+    mRectScisor.h = mRenderer_h;
+}
+
+// Called by Rocket when it wants to render geometry that it does not wish to optimise.
+void RocketSDL2Renderer::RenderGeometry(Rocket::Core::Vertex* vertices, int num_vertices, int* indices, int num_indices, const Rocket::Core::TextureHandle texture, const Rocket::Core::Vector2f& translation)
+{
+    SDL_Texture *sdl_texture = (SDL_Texture *) texture;
+
+    SDL_Rect r;
+    r.x = translation.x;
+    r.y = translation.y;
+    r.w = mRenderer_w - r.x;
+    r.h = mRenderer_h - r.y;
+    
+    SDL_RenderSetViewport(mRenderer, &r);
+
+    if (sdl_texture) {
+        SDL_SetTextureBlendMode(sdl_texture, SDL_BLENDMODE_BLEND);
+    }
+
+    int sz = sizeof(vertices[0]);
+    int off1 = offsetof(Rocket::Core::Vertex, position);
+    int off2 = offsetof(Rocket::Core::Vertex, colour);
+    int off3 = offsetof(Rocket::Core::Vertex, tex_coord);
+    SDL_RenderGeometryRaw(mRenderer, sdl_texture, 
+            (float *)((Uint8 *) vertices + off1), sz,
+            (int *)((Uint8 *) vertices + off2), sz,
+            (float *)((Uint8 *) vertices + off3), sz,
+            num_vertices, indices, num_indices, 4);
+
+}
+
+
+// Called by Rocket when it wants to enable or disable scissoring to clip content.		
+void RocketSDL2Renderer::EnableScissorRegion(bool enable)
+{
+    if (enable) {
+        SDL_RenderSetClipRect(mRenderer, &mRectScisor);
+    } else {
+        SDL_RenderSetClipRect(mRenderer, NULL);
+    }
+}
+
+// Called by Rocket when it wants to change the scissor region.		
+void RocketSDL2Renderer::SetScissorRegion(int x, int y, int width, int height)
+{
+    int w_width, w_height;
+    SDL_GetWindowSize(mScreen, &w_width, &w_height);
+    mRectScisor.x = x;
+    mRectScisor.y = w_height - (y + height);
+    mRectScisor.w = width;
+    mRectScisor.h = height;
+}
+
+// Called by Rocket when a texture is required by the library.		
+bool RocketSDL2Renderer::LoadTexture(Rocket::Core::TextureHandle& texture_handle, Rocket::Core::Vector2i& texture_dimensions, const Rocket::Core::String& source)
+{
+
+    Rocket::Core::FileInterface* file_interface = Rocket::Core::GetFileInterface();
+    Rocket::Core::FileHandle file_handle = file_interface->Open(source);
+    if (!file_handle)
+        return false;
+
+    file_interface->Seek(file_handle, 0, SEEK_END);
+    size_t buffer_size = file_interface->Tell(file_handle);
+    file_interface->Seek(file_handle, 0, SEEK_SET);
+
+    char* buffer = new char[buffer_size];
+    file_interface->Read(buffer, buffer_size, file_handle);
+    file_interface->Close(file_handle);
+
+    size_t i;
+    for(i = source.Length() - 1; i > 0; i--)
+    {
+        if(source[i] == '.')
+            break;
+    }
+
+    Rocket::Core::String extension = source.Substring(i+1, source.Length()-i);
+
+    SDL_Surface* surface = IMG_LoadTyped_RW(SDL_RWFromMem(buffer, buffer_size), 1, extension.CString());
+
+    if (surface) {
+        SDL_Texture *texture = SDL_CreateTextureFromSurface(mRenderer, surface);
+
+        if (texture) {
+            texture_handle = (Rocket::Core::TextureHandle) texture;
+            texture_dimensions = Rocket::Core::Vector2i(surface->w, surface->h);
+            SDL_FreeSurface(surface);
+        }
+        else
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+// Called by Rocket when a texture is required to be built from an internally-generated sequence of pixels.
+bool RocketSDL2Renderer::GenerateTexture(Rocket::Core::TextureHandle& texture_handle, const Rocket::Core::byte* source, const Rocket::Core::Vector2i& source_dimensions)
+{
+    #if SDL_BYTEORDER == SDL_BIG_ENDIAN
+        Uint32 rmask = 0xff000000;
+        Uint32 gmask = 0x00ff0000;
+        Uint32 bmask = 0x0000ff00;
+        Uint32 amask = 0x000000ff;
+    #else
+        Uint32 rmask = 0x000000ff;
+        Uint32 gmask = 0x0000ff00;
+        Uint32 bmask = 0x00ff0000;
+        Uint32 amask = 0xff000000;
+    #endif
+
+    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom ((void*) source, source_dimensions.x, source_dimensions.y, 32, source_dimensions.x*4, rmask, gmask, bmask, amask);
+    SDL_Texture *texture = SDL_CreateTextureFromSurface(mRenderer, surface);
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+    SDL_FreeSurface(surface);
+    texture_handle = (Rocket::Core::TextureHandle) texture;
+    return true;
+}
+
+// Called by Rocket when a loaded texture is no longer required.		
+void RocketSDL2Renderer::ReleaseTexture(Rocket::Core::TextureHandle texture_handle)
+{
+    SDL_DestroyTexture((SDL_Texture*) texture_handle);
+}
+

--- a/Samples/basic/sdl2_sdlrenderer/src/RenderInterfaceSDL2.h
+++ b/Samples/basic/sdl2_sdlrenderer/src/RenderInterfaceSDL2.h
@@ -1,0 +1,67 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 Nuno Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#ifndef RENDERINTERFACESDL2_H
+#define RENDERINTERFACESDL2_H
+
+#include <Rocket/Core/RenderInterface.h>
+
+#include <SDL.h>
+
+#if !(SDL_VIDEO_RENDER_OGL)
+    #error "Only the opengl sdl backend is supported. To add support for others, see http://mdqinc.com/blog/2013/01/integrating-librocket-with-sdl-2/"
+#endif
+
+
+class RocketSDL2Renderer : public Rocket::Core::RenderInterface
+{
+public:
+	RocketSDL2Renderer(SDL_Renderer* renderer, SDL_Window* screen);
+
+	/// Called by Rocket when it wants to render geometry that it does not wish to optimise.
+	virtual void RenderGeometry(Rocket::Core::Vertex* vertices, int num_vertices, int* indices, int num_indices, Rocket::Core::TextureHandle texture, const Rocket::Core::Vector2f& translation);
+
+	/// Called by Rocket when it wants to enable or disable scissoring to clip content.
+	virtual void EnableScissorRegion(bool enable);
+	/// Called by Rocket when it wants to change the scissor region.
+	virtual void SetScissorRegion(int x, int y, int width, int height);
+
+	/// Called by Rocket when a texture is required by the library.
+	virtual bool LoadTexture(Rocket::Core::TextureHandle& texture_handle, Rocket::Core::Vector2i& texture_dimensions, const Rocket::Core::String& source);
+	/// Called by Rocket when a texture is required to be built from an internally-generated sequence of pixels.
+	virtual bool GenerateTexture(Rocket::Core::TextureHandle& texture_handle, const Rocket::Core::byte* source, const Rocket::Core::Vector2i& source_dimensions);
+	/// Called by Rocket when a loaded texture is no longer required.
+	virtual void ReleaseTexture(Rocket::Core::TextureHandle texture_handle);
+
+private:
+    SDL_Renderer* mRenderer;
+    int mRenderer_w;
+    int mRenderer_h;
+    SDL_Window* mScreen;
+    SDL_Rect mRectScisor;
+};
+
+#endif

--- a/Samples/basic/sdl2_sdlrenderer/src/SystemInterfaceSDL2.cpp
+++ b/Samples/basic/sdl2_sdlrenderer/src/SystemInterfaceSDL2.cpp
@@ -1,0 +1,441 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 Nuno Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#include <Rocket/Core.h>
+#include "SystemInterfaceSDL2.h"
+
+Rocket::Core::Input::KeyIdentifier RocketSDL2SystemInterface::TranslateKey(SDL_Keycode sdlkey)
+{
+    using namespace Rocket::Core::Input;
+
+
+    switch(sdlkey) {
+        case SDLK_UNKNOWN:
+            return KI_UNKNOWN;
+            break;
+        case SDLK_SPACE:
+            return KI_SPACE;
+            break;
+        case SDLK_0:
+            return KI_0;
+            break;
+        case SDLK_1:
+            return KI_1;
+            break;
+        case SDLK_2:
+            return KI_2;
+            break;
+        case SDLK_3:
+            return KI_3;
+            break;
+        case SDLK_4:
+            return KI_4;
+            break;
+        case SDLK_5:
+            return KI_5;
+            break;
+        case SDLK_6:
+            return KI_6;
+            break;
+        case SDLK_7:
+            return KI_7;
+            break;
+        case SDLK_8:
+            return KI_8;
+            break;
+        case SDLK_9:
+            return KI_9;
+            break;
+        case SDLK_a:
+            return KI_A;
+            break;
+        case SDLK_b:
+            return KI_B;
+            break;
+        case SDLK_c:
+            return KI_C;
+            break;
+        case SDLK_d:
+            return KI_D;
+            break;
+        case SDLK_e:
+            return KI_E;
+            break;
+        case SDLK_f:
+            return KI_F;
+            break;
+        case SDLK_g:
+            return KI_G;
+            break;
+        case SDLK_h:
+            return KI_H;
+            break;
+        case SDLK_i:
+            return KI_I;
+            break;
+        case SDLK_j:
+            return KI_J;
+            break;
+        case SDLK_k:
+            return KI_K;
+            break;
+        case SDLK_l:
+            return KI_L;
+            break;
+        case SDLK_m:
+            return KI_M;
+            break;
+        case SDLK_n:
+            return KI_N;
+            break;
+        case SDLK_o:
+            return KI_O;
+            break;
+        case SDLK_p:
+            return KI_P;
+            break;
+        case SDLK_q:
+            return KI_Q;
+            break;
+        case SDLK_r:
+            return KI_R;
+            break;
+        case SDLK_s:
+            return KI_S;
+            break;
+        case SDLK_t:
+            return KI_T;
+            break;
+        case SDLK_u:
+            return KI_U;
+            break;
+        case SDLK_v:
+            return KI_V;
+            break;
+        case SDLK_w:
+            return KI_W;
+            break;
+        case SDLK_x:
+            return KI_X;
+            break;
+        case SDLK_y:
+            return KI_Y;
+            break;
+        case SDLK_z:
+            return KI_Z;
+            break;
+        case SDLK_SEMICOLON:
+            return KI_OEM_1;
+            break;
+        case SDLK_PLUS:
+            return KI_OEM_PLUS;
+            break;
+        case SDLK_COMMA:
+            return KI_OEM_COMMA;
+            break;
+        case SDLK_MINUS:
+            return KI_OEM_MINUS;
+            break;
+        case SDLK_PERIOD:
+            return KI_OEM_PERIOD;
+            break;
+        case SDLK_SLASH:
+            return KI_OEM_2;
+            break;
+        case SDLK_BACKQUOTE:
+            return KI_OEM_3;
+            break;
+        case SDLK_LEFTBRACKET:
+            return KI_OEM_4;
+            break;
+        case SDLK_BACKSLASH:
+            return KI_OEM_5;
+            break;
+        case SDLK_RIGHTBRACKET:
+            return KI_OEM_6;
+            break;
+        case SDLK_QUOTEDBL:
+            return KI_OEM_7;
+            break;
+        case SDLK_KP_0:
+            return KI_NUMPAD0;
+            break;
+        case SDLK_KP_1:
+            return KI_NUMPAD1;
+            break;
+        case SDLK_KP_2:
+            return KI_NUMPAD2;
+            break;
+        case SDLK_KP_3:
+            return KI_NUMPAD3;
+            break;
+        case SDLK_KP_4:
+            return KI_NUMPAD4;
+            break;
+        case SDLK_KP_5:
+            return KI_NUMPAD5;
+            break;
+        case SDLK_KP_6:
+            return KI_NUMPAD6;
+            break;
+        case SDLK_KP_7:
+            return KI_NUMPAD7;
+            break;
+        case SDLK_KP_8:
+            return KI_NUMPAD8;
+            break;
+        case SDLK_KP_9:
+            return KI_NUMPAD9;
+            break;
+        case SDLK_KP_ENTER:
+            return KI_NUMPADENTER;
+            break;
+        case SDLK_KP_MULTIPLY:
+            return KI_MULTIPLY;
+            break;
+        case SDLK_KP_PLUS:
+            return KI_ADD;
+            break;
+        case SDLK_KP_MINUS:
+            return KI_SUBTRACT;
+            break;
+        case SDLK_KP_PERIOD:
+            return KI_DECIMAL;
+            break;
+        case SDLK_KP_DIVIDE:
+            return KI_DIVIDE;
+            break;
+        case SDLK_KP_EQUALS:
+            return KI_OEM_NEC_EQUAL;
+            break;
+        case SDLK_BACKSPACE:
+            return KI_BACK;
+            break;
+        case SDLK_TAB:
+            return KI_TAB;
+            break;
+        case SDLK_CLEAR:
+            return KI_CLEAR;
+            break;
+        case SDLK_RETURN:
+            return KI_RETURN;
+            break;
+        case SDLK_PAUSE:
+            return KI_PAUSE;
+            break;
+        case SDLK_CAPSLOCK:
+            return KI_CAPITAL;
+            break;
+        case SDLK_PAGEUP:
+            return KI_PRIOR;
+            break;
+        case SDLK_PAGEDOWN:
+            return KI_NEXT;
+            break;
+        case SDLK_END:
+            return KI_END;
+            break;
+        case SDLK_HOME:
+            return KI_HOME;
+            break;
+        case SDLK_LEFT:
+            return KI_LEFT;
+            break;
+        case SDLK_UP:
+            return KI_UP;
+            break;
+        case SDLK_RIGHT:
+            return KI_RIGHT;
+            break;
+        case SDLK_DOWN:
+            return KI_DOWN;
+            break;
+        case SDLK_INSERT:
+            return KI_INSERT;
+            break;
+        case SDLK_DELETE:
+            return KI_DELETE;
+            break;
+        case SDLK_HELP:
+            return KI_HELP;
+            break;
+        case SDLK_F1:
+            return KI_F1;
+            break;
+        case SDLK_F2:
+            return KI_F2;
+            break;
+        case SDLK_F3:
+            return KI_F3;
+            break;
+        case SDLK_F4:
+            return KI_F4;
+            break;
+        case SDLK_F5:
+            return KI_F5;
+            break;
+        case SDLK_F6:
+            return KI_F6;
+            break;
+        case SDLK_F7:
+            return KI_F7;
+            break;
+        case SDLK_F8:
+            return KI_F8;
+            break;
+        case SDLK_F9:
+            return KI_F9;
+            break;
+        case SDLK_F10:
+            return KI_F10;
+            break;
+        case SDLK_F11:
+            return KI_F11;
+            break;
+        case SDLK_F12:
+            return KI_F12;
+            break;
+        case SDLK_F13:
+            return KI_F13;
+            break;
+        case SDLK_F14:
+            return KI_F14;
+            break;
+        case SDLK_F15:
+            return KI_F15;
+            break;
+        case SDLK_NUMLOCKCLEAR:
+            return KI_NUMLOCK;
+            break;
+        case SDLK_SCROLLLOCK:
+            return KI_SCROLL;
+            break;
+        case SDLK_LSHIFT:
+            return KI_LSHIFT;
+            break;
+        case SDLK_RSHIFT:
+            return KI_RSHIFT;
+            break;
+        case SDLK_LCTRL:
+            return KI_LCONTROL;
+            break;
+        case SDLK_RCTRL:
+            return KI_RCONTROL;
+            break;
+        case SDLK_LALT:
+            return KI_LMENU;
+            break;
+        case SDLK_RALT:
+            return KI_RMENU;
+            break;
+        case SDLK_LGUI:
+            return KI_LMETA;
+            break;
+        case SDLK_RGUI:
+            return KI_RMETA;
+            break;
+        /*case SDLK_LSUPER:
+            return KI_LWIN;
+            break;
+        case SDLK_RSUPER:
+            return KI_RWIN;
+            break;*/
+        default:
+            return KI_UNKNOWN;
+            break;
+    }
+}
+
+int RocketSDL2SystemInterface::TranslateMouseButton(Uint8 button)
+{
+    switch(button)
+    {
+        case SDL_BUTTON_LEFT:
+            return 0;
+        case SDL_BUTTON_RIGHT:
+            return 1;
+        case SDL_BUTTON_MIDDLE:
+            return 2;
+        default:
+            return 3;
+    }
+}
+
+int RocketSDL2SystemInterface::GetKeyModifiers()
+{
+    SDL_Keymod sdlMods = SDL_GetModState();
+
+    int retval = 0;
+
+    if(sdlMods & KMOD_CTRL)
+        retval |= Rocket::Core::Input::KM_CTRL;
+
+    if(sdlMods & KMOD_SHIFT)
+        retval |= Rocket::Core::Input::KM_SHIFT;
+
+    if(sdlMods & KMOD_ALT)
+        retval |= Rocket::Core::Input::KM_ALT;
+
+    return retval;
+}
+
+float RocketSDL2SystemInterface::GetElapsedTime()
+{
+	return SDL_GetTicks() / 1000;
+}
+
+bool RocketSDL2SystemInterface::LogMessage(Rocket::Core::Log::Type type, const Rocket::Core::String& message)
+{
+	std::string Type;
+
+	switch(type)
+	{
+	case Rocket::Core::Log::LT_ALWAYS:
+		Type = "[Always]";
+		break;
+	case Rocket::Core::Log::LT_ERROR:
+		Type = "[Error]";
+		break;
+	case Rocket::Core::Log::LT_ASSERT:
+		Type = "[Assert]";
+		break;
+	case Rocket::Core::Log::LT_WARNING:
+		Type = "[Warning]";
+		break;
+	case Rocket::Core::Log::LT_INFO:
+		Type = "[Info]";
+		break;
+	case Rocket::Core::Log::LT_DEBUG:
+		Type = "[Debug]";
+		break;
+    case Rocket::Core::Log::LT_MAX:
+        break;
+	};
+
+	printf("%s - %s\n", Type.c_str(), message.CString());
+
+	return true;
+};

--- a/Samples/basic/sdl2_sdlrenderer/src/SystemInterfaceSDL2.h
+++ b/Samples/basic/sdl2_sdlrenderer/src/SystemInterfaceSDL2.h
@@ -1,0 +1,44 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 Nuno Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#ifndef SYSTEMINTEFACESDL2_H
+#define SYSTEMINTEFACESDL2_H
+
+#include <Rocket/Core/SystemInterface.h>
+#include <Rocket/Core/Input.h>
+
+#include <SDL.h>
+
+class RocketSDL2SystemInterface : public Rocket::Core::SystemInterface
+{
+public:
+    Rocket::Core::Input::KeyIdentifier TranslateKey(SDL_Keycode sdlkey);
+    int TranslateMouseButton(Uint8 button);
+	int GetKeyModifiers();
+	float GetElapsedTime();
+    bool LogMessage(Rocket::Core::Log::Type type, const Rocket::Core::String& message);
+};
+#endif

--- a/Samples/basic/sdl2_sdlrenderer/src/main.cpp
+++ b/Samples/basic/sdl2_sdlrenderer/src/main.cpp
@@ -1,0 +1,160 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 Nuno Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <Rocket/Core.h>
+#include <Rocket/Core/Input.h>
+#include <Rocket/Debugger/Debugger.h>
+#include <ShellFileInterface.h>
+
+#include "SystemInterfaceSDL2.h"
+#include "RenderInterfaceSDL2.h"
+
+#include <SDL.h>
+
+int main(int argc, char **argv)
+{
+#ifdef ROCKET_PLATFORM_LINUX
+#define APP_PATH "../Samples/basic/sdl2/"
+#else
+#ifdef ROCKET_PLATFORM_MACOSX
+#define APP_PATH "../../../../../Samples/basic/sdl2_sdlrenderer/"
+#else
+#define APP_PATH "../../Samples/basic/sdl2_sdlrenderer/"
+#endif
+#endif
+
+#ifdef ROCKET_PLATFORM_WIN32
+        DoAllocConsole();
+#endif
+
+        int window_width = 1024;
+        int window_height = 768;
+
+    SDL_Init( SDL_INIT_VIDEO );
+    SDL_Window * screen = SDL_CreateWindow("LibRocket SDL2 with SDL_Renderer test", 20, 20, window_width, window_height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    SDL_Renderer * renderer = SDL_CreateRenderer(screen, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+
+	RocketSDL2Renderer Renderer(renderer, screen);
+	RocketSDL2SystemInterface SystemInterface;
+	ShellFileInterface FileInterface("../Samples/assets/");
+
+	Rocket::Core::SetFileInterface(&FileInterface);
+	Rocket::Core::SetRenderInterface(&Renderer);
+    Rocket::Core::SetSystemInterface(&SystemInterface);
+
+	if(!Rocket::Core::Initialise())
+		return 1;
+
+	Rocket::Core::FontDatabase::LoadFontFace("Delicious-Bold.otf");
+	Rocket::Core::FontDatabase::LoadFontFace("Delicious-BoldItalic.otf");
+	Rocket::Core::FontDatabase::LoadFontFace("Delicious-Italic.otf");
+	Rocket::Core::FontDatabase::LoadFontFace("Delicious-Roman.otf");
+
+	Rocket::Core::Context *Context = Rocket::Core::CreateContext("default",
+		Rocket::Core::Vector2i(window_width, window_height));
+
+	Rocket::Debugger::Initialise(Context);
+
+	Rocket::Core::ElementDocument *Document = Context->LoadDocument("demo.rml");
+
+	if(Document)
+	{
+		Document->Show();
+		Document->RemoveReference();
+		fprintf(stdout, "\nDocument loaded");
+	}
+	else
+	{
+		fprintf(stdout, "\nDocument is NULL");
+	}
+
+    bool done = false;
+
+	while(!done)
+	{
+        SDL_Event event;
+
+        SDL_SetRenderDrawColor(renderer, 0, 0, 255, 255);
+        SDL_RenderClear(renderer);
+
+		Context->Render();
+        SDL_RenderPresent(renderer);
+
+        while(SDL_PollEvent(&event))
+        {
+            switch(event.type)
+            {
+                case SDL_QUIT:
+                    done = true;
+                    break;
+
+                case SDL_MOUSEMOTION:
+                    Context->ProcessMouseMove(event.motion.x, event.motion.y, SystemInterface.GetKeyModifiers());
+                    break;
+                case SDL_MOUSEBUTTONDOWN:
+                    Context->ProcessMouseButtonDown(SystemInterface.TranslateMouseButton(event.button.button), SystemInterface.GetKeyModifiers());
+                    break;
+
+                case SDL_MOUSEBUTTONUP:
+                    Context->ProcessMouseButtonUp(SystemInterface.TranslateMouseButton(event.button.button), SystemInterface.GetKeyModifiers());
+                    break;
+
+                case SDL_MOUSEWHEEL:
+                    Context->ProcessMouseWheel(event.wheel.y, SystemInterface.GetKeyModifiers());
+                    break;
+
+                case SDL_KEYDOWN:
+                {
+                    // Intercept SHIFT + ~ key stroke to toggle libRocket's 
+                    // visual debugger tool
+                    if( event.key.keysym.sym == SDLK_BACKQUOTE && 
+                        event.key.keysym.mod == KMOD_LSHIFT )
+                    {
+                        Rocket::Debugger::SetVisible( ! Rocket::Debugger::IsVisible() );
+                        break;
+                    }
+                    
+                    Context->ProcessKeyDown(SystemInterface.TranslateKey(event.key.keysym.sym), SystemInterface.GetKeyModifiers());
+                    break;
+                }
+                
+                default:
+                    break;
+            }
+        }
+		Context->Update();
+	}
+
+    Context->RemoveReference();
+    Rocket::Core::Shutdown();
+
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(screen);
+    SDL_Quit();
+
+	return 0;
+};


### PR DESCRIPTION
Provide an example to build libRocket using SDL2 / SDL_RenderGeometry (using this PR libsdl-org/SDL#4195)

Which makes libRocket using the platform backend available (opengl, opengles2, Direct3D11, Metal, or software rendering).